### PR TITLE
Bug 1587555: Add scopes necessary for docker-worker CI

### DIFF
--- a/generate/repo_access.py
+++ b/generate/repo_access.py
@@ -34,6 +34,22 @@ repo_access = [
             'github.com/taskcluster/taskcluster:*',
         ]
     },
+    {
+        'scopes': [
+            'docker-worker:cache:docker-worker-garbage-*',
+            'docker-worker:capability:privileged',
+            'docker-worker:capability:device:loopbackAudio',
+            'docker-worker:capability:device:loopbackVideo',
+            'project/taskcluster/testing/docker-worker/ci-creds',
+            'project/taskcluster/testing/docker-worker/pulse-creds',
+        ],
+        'worker-pools': [
+            'proj-taskcluster/ci',
+        ],
+        'for': [
+            'github.com/taskcluster/docker-worker:*',
+        ],
+    }
 ]
 
 


### PR DESCRIPTION
```
vagrant@vagrant:community-tc-config  (docker-worker-scopes)$ TASKCLUSTER_ROOT_URL=https://community-tc.services.mozilla.com tc-admin diff --grep docker-worker
--- current
+++ generated
@@ -3,9 +3,22 @@
   - Role=repo:.*
   - Role=project-admin:.*
   - Role=github-org-admin:.*
   - Role=github-team:.*
   - Role=login-identity:.*
   - WorkerPool=proj-.*

 resources:
+  Role=repo:github.com/taskcluster/docker-worker:
+    roleId: repo:github.com/taskcluster/docker-worker
+    description:
+      *DO NOT EDIT* - This resource is configured automatically.

+
+    scopes:
+      - docker-worker:cache:docker-worker-garbage-*
+      - docker-worker:capability:device:loopbackAudio
+      - docker-worker:capability:device:loopbackVideo
+      - docker-worker:capability:privileged
+      - queue:create-task:highest:proj-taskcluster/ci
+      - secrets:get:repo:github.com/taskcluster/docker-worker/ci-creds
+      - secrets:get:repo:github.com/taskcluster/docker-worker/pulse-creds
```