### PR TITLE
Add pytest as install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     install_requires=[
         "tc-admin~=1.0.0",
         "json-e~=3.0.0",
+        "pytest~=5.2.1",
     ],
     setup_requires=["pytest-runner", "flake8"],
     tests_require=["pytest-mock", "pytest-asyncio", "flake8"],


### PR DESCRIPTION
I had problems running tc-admin, which this change fixed.

I'm not sure why `pytest` is needed when just running tc-admin, but it seemed to help. This could be the wrong fix, so please check I put the dependency in the right place. Thanks!

This is the script I was running:

```bash
#!/bin/bash

cd "$(dirname "${0}")"

rm -rf tc-admin
mkdir tc-admin
pip3 install --upgrade pip

cd tc-admin
python3 -m venv tc-admin-venv
source tc-admin-venv/bin/activate
pip3 install --upgrade pip

git clone https://github.com/mozilla/community-tc-config
cd community-tc-config
pip3 install -e .
which tc-admin
TASKCLUSTER_ROOT_URL=https://community-tc.services.mozilla.com tc-admin diff
```

This is the output I was getting:

```
Requirement already up-to-date: pip in /usr/local/lib/python3.7/site-packages (19.2.3)
Collecting pip
  Using cached https://files.pythonhosted.org/packages/30/db/9e38760b32e3e7f40cce46dd5fb107b8c73840df38f0046d8e6514e675a1/pip-19.2.3-py2.py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 19.0.3
    Uninstalling pip-19.0.3:
      Successfully uninstalled pip-19.0.3
Successfully installed pip-19.2.3
Cloning into 'community-tc-config'...
remote: Enumerating objects: 89, done.
remote: Counting objects: 100% (89/89), done.
remote: Compressing objects: 100% (60/60), done.
remote: Total 89 (delta 49), reused 50 (delta 24), pack-reused 0
Unpacking objects: 100% (89/89), done.
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
Obtaining file:///Users/pmoore/tc-admin/community-tc-config
Collecting tc-admin~=1.0.0 (from community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/dc/ce/97b0212191ac6c675b62b9e92e9d405d64e6f7514ec3de287def0e92eba9/tc_admin-1.0.0-py3-none-any.whl
Collecting json-e~=3.0.0 (from community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/98/37/efe9813b85989e716f8cde7ab716f17ff98e1e18f68666d522eadd4680a8/json-e-3.0.0.tar.gz
Collecting aiohttp<3 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting pyyaml<4 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting blessings<2 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/03/74/489f85a78247609c6b4f13733cbf3ba0d864b11aa565617b645d6fdf2a4a/blessings-1.7-py3-none-any.whl
Collecting sortedcontainers<3 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/13/f3/cf85f7c3a2dbd1a515d51e1f1676d971abe41bba6f4ab5443240d9a78e5b/sortedcontainers-2.1.0-py2.py3-none-any.whl
Collecting iso8601==0.1.12 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ef/57/7162609dab394d38bbc7077b7ba0a6f10fb09d8b7701ea56fa1edc0c4345/iso8601-0.1.12-py2.py3-none-any.whl
Collecting memoized==0.3 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting attrs (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/6b/e8/2ecaf86b128a34e225807f03b22664302937ab826bd3b7eccab6754d29ea/attrs-19.2.0-py2.py3-none-any.whl
Collecting click<7 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl
Collecting taskcluster~=16.0.0 (from tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/d1/51/144213d5ede712f9131ffd6f02c3ee5609c5f39c9b0bd81cf4fda2dc8ba5/taskcluster-16.0.0-py3-none-any.whl
Collecting yarl>=1.0.0 (from aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting multidict>=4.0.0 (from aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/0e/64/39b167d63e292cc2336d09c4d3577089db82cd7886ed535b6100fc7c7966/multidict-4.5.2-cp37-cp37m-macosx_10_12_intel.macosx_10_12_x86_64.macosx_10_13_intel.macosx_10_13_x86_64.whl
Collecting idna-ssl>=1.0.0 (from aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting async-timeout>=1.2.0 (from aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e1/1e/5a4441be21b0726c4464f3f23c8b19628372f606755a9d2e46c187e65ec4/async_timeout-3.0.1-py3-none-any.whl
Collecting chardet (from aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting six (from blessings<2->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting requests>=2.4.3 (from taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Collecting slugid>=2 (from taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/6f/f7/0e7d06fa6914e2694d9766a827409fef1000f7548ba869b2476ff5817d86/slugid-2.0.0-py2.py3-none-any.whl
Collecting taskcluster-urls>=10.1.0 (from taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/cf/24/ae4f15fec931d7cba98c8ff6ec93353c12c7fb07ef91b256113b3431f834/taskcluster_urls-11.0.0-py3-none-any.whl
Collecting mohawk>=0.3.4 (from taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
Collecting idna>=2.0 (from yarl>=1.0.0->aiohttp<3->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.4.3->taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/18/b0/8146a4f8dd402f60744fa380bc73ca47303cccf8b9190fd16a827281eac2/certifi-2019.9.11-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.4.3->taskcluster~=16.0.0->tc-admin~=1.0.0->community-tc-config==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e0/da/55f51ea951e1b7c63a579c09dd7db825bb730ec1fe9c0180fc77bfb31448/urllib3-1.25.6-py2.py3-none-any.whl
Installing collected packages: idna, multidict, yarl, idna-ssl, async-timeout, chardet, aiohttp, pyyaml, six, blessings, sortedcontainers, iso8601, memoized, attrs, click, certifi, urllib3, requests, slugid, taskcluster-urls, mohawk, taskcluster, tc-admin, json-e, community-tc-config
  Running setup.py install for json-e ... done
  Running setup.py develop for community-tc-config
Successfully installed aiohttp-2.3.10 async-timeout-3.0.1 attrs-19.2.0 blessings-1.7 certifi-2019.9.11 chardet-3.0.4 click-6.7 community-tc-config idna-2.8 idna-ssl-1.1.0 iso8601-0.1.12 json-e-3.0.0 memoized-0.3 mohawk-1.0.0 multidict-4.5.2 pyyaml-3.13 requests-2.22.0 six-1.12.0 slugid-2.0.0 sortedcontainers-2.1.0 taskcluster-16.0.0 taskcluster-urls-11.0.0 tc-admin-1.0.0 urllib3-1.25.6 yarl-1.3.0
/Users/pmoore/tc-admin/tc-admin-venv/bin/tc-admin
Traceback (most recent call last):
  File "/Users/pmoore/tc-admin/tc-admin-venv/bin/tc-admin", line 6, in <module>
    from tcadmin.boot import boot
  File "/Users/pmoore/tc-admin/tc-admin-venv/lib/python3.7/site-packages/tcadmin/boot.py", line 10, in <module>
    from .main import main
  File "/Users/pmoore/tc-admin/tc-admin-venv/lib/python3.7/site-packages/tcadmin/main.py", line 19, in <module>
    from . import check
  File "/Users/pmoore/tc-admin/tc-admin-venv/lib/python3.7/site-packages/tcadmin/check.py", line 7, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'
```