### PR TITLE
[bug 1578411] Add basics of a relman project with some microannotate scopes

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -111,6 +111,22 @@ bors-ng:
     - grant: queue:create-task:highest:proj-bors-ng/ci
       to: repo:github.com/bors-ng/bors-ng:*
 
+relman:
+  adminRoles:
+    - github-team:mozilla/release-management
+  workerPools:
+    ci:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      type: standard_gcp_docker_worker
+      minCapacity: 0
+      maxCapacity: 2
+  grants:
+    - grant: secrets:get:project/relman/microannotate/deploy
+      to: repo:github.com/mozilla/microannotate:tag:*
+    - grant: queue:create-task:highest:proj-relman/ci
+      to: repo:github.com/mozilla/microannotate:*
+
 # catch-all repo for simple mozilla projects
 # if you need more complexity, talk to the taskcluster team!
 misc:


### PR DESCRIPTION
@marco-c, this should set up the workers and such that microannotate needs in the community cluster. It will put the resources inside a `relman` project since it seems like the current taskcluster.net deployment has a bunch of scopes managed under that.

The questions I have for you are:
1. Do you have an email you'd prefer for `owner` below? I just used whatever was in the `owner` field of the `.taskcluster.yml` in microannotate. Is there a team email you'd prefer?
2. Is it ok that it seems like only some relman projects are going into the community cluster and others are going into the firefox-ci cluster. Would it be preferable for everything to be in one place? @tomprince, do you have an opinion on this?

After we figure these things out, I'll make a PR to the microannotate project to update it to being in the new cluster!