### PR TITLE
Add support for configuring per-project clients

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -17,6 +17,10 @@
 #       emailOnError: ..
 #       type: <name of a function in `generate/workers.py`)
 #       ..: ..  # arguments to that function
+#   clients:
+#     <clientId-suffix>:  # suffix after `project/<project-name>/`
+#       scopes: [ .. ]
+#       description: ..   # optional
 #   grants:  # (same format as grants.yml)
 #
 # The worker-pool configurations are defined by Python functions, keyed by the `type` property.


### PR DESCRIPTION
This is useful for generating standalone worker credentials, for example.