### PR TITLE
Move login-identity:* into grants, add scheduler-id:-

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -88,6 +88,17 @@
     - assume:repo:<..>
   to: repo-admin:*
 
+- grant:
+    # support users' creation of clients
+    - auth:create-client:<..>/*
+    - auth:delete-client:<..>/*
+    - auth:update-client:<..>/*
+    - auth:reset-access-token:<..>/*
+    # grant all users access to scheduler-id `-`, the default
+    - queue:scheduler-id:-
+  to:
+    - login-identity:*
+
 # Grant permission to use websocktunnel with audience `communitytc` to all
 # workers in all pools
 - grant: auth:websocktunnel-token:communitytc/*

--- a/generate/__init__.py
+++ b/generate/__init__.py
@@ -6,7 +6,7 @@
 
 import re
 
-from . import projects, login_identity, grants
+from . import projects, grants
 
 
 async def update_resources(resources):
@@ -19,5 +19,4 @@ async def update_resources(resources):
     resources.manage(re.compile(r"(?!{}).*".format(em_bar)))
 
     await projects.update_resources(resources)
-    await login_identity.update_resources(resources)
     await grants.update_resources(resources)

--- a/generate/login_identity.py
+++ b/generate/login_identity.py
@@ -17,14 +17,3 @@ users = {
 }
 
 async def update_resources(resources):
-    resources.add(Role(
-        roleId="login-identity:*",
-        description=textwrap.dedent("""\
-            Scopes for anyone who logs into the service;
-            see [login-identities docs](https://docs.taskcluster.net/docs/manual/design/conventions/login-identities)."""),
-        scopes=[
-            'auth:create-client:<..>/*',
-            'auth:delete-client:<..>/*',
-            'auth:reset-access-token:<..>/*',
-            'auth:update-client:<..>/*',
-        ]))


### PR DESCRIPTION
The `login-identity:*` role was overlooked when moving other
parameterized roles into `grants.yml` -- oops!

This also adds `scheduler-id:-` for all logged-in users.  This
schedulerId is the default, so is used for tasks created with "task
creator".  Adding it doesn't hurt.