### PR TITLE
Set up project relman stuff in its entirety

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -227,3 +227,36 @@ git-cinnabar:
         - repo:github.com/glandium/git-cinnabar:release
         - repo:github.com/glandium/git-cinnabar:branch:*
         - repo:github.com/glandium/git-cinnabar:tag:*
+
+relman:
+  adminRoles:
+    - github-team:mozilla/release-management
+  workerPools:
+    ci:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      type: standard_gcp_docker_worker
+      minCapacity: 1
+      maxCapacity: 50
+  grants:
+    - grant: queue:create-task:highest:proj-relman/ci
+      to:
+        - repo:github.com/mozilla/bugbug:*
+        - repo:github.com/mozilla/microannotate:*
+        - repo:github.com/rail/taskboot-test:*
+        - repo:github.com/mozilla/code-coverage:*
+        - repo:github.com/mozilla/code-review:*
+    - grant:
+        - docker-worker:cache:bugbug-build
+        - docker-worker:cache:bugbug-mercurial-repository
+        - docker-worker:capability:privileged
+        - secrets:get:project/relman/bugbug/integration
+      to: repo:github.com/mozilla/bugbug:*
+    - grant:
+        - docker-worker:capability:privileged
+        - queue:route:statuses
+      to: repo:github.com/mozilla/code-coverage:*
+    - grant:
+        - docker-worker:capability:privileged
+        - queue:route:statuses
+      to: repo:github.com/mozilla/code-review:*


### PR DESCRIPTION
This is much simpler than what is in the old deployment right now
because we can't deploy across deployments