### PR TITLE
Move taskcluster_yml_validator to the misc project

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -221,22 +221,6 @@ redo:
     - grant: queue:create-task:highest:proj-redo/ci
       to: repo:github.com/mozilla-releng/redo:*
 
-taskcluster_yml_validator:
-  adminRoles:
-    - login-identity:github/1616846|marco-c
-  repos:
-    - github.com/marco-c/taskcluster_yml_validator:*
-  workerPools:
-    ci:
-      owner: mcastelluccio@mozilla.com
-      emailOnError: false
-      type: standard_gcp_docker_worker
-      minCapacity: 0
-      maxCapacity: 2
-  grants:
-    - grant: queue:create-task:highest:proj-taskcluster_yml_validator/ci
-      to: repo:github.com/marco-c/taskcluster_yml_validator:*
-
 # catch-all repo for simple mozilla projects
 # if you need more complexity, talk to the taskcluster team!
 misc:
@@ -244,6 +228,7 @@ misc:
     - github-team:taskcluster/core
   repos:
     - github.com/mozilla/*
+    - github.com/marco-c/taskcluster_yml_validator:*
   workerPools:
     ci:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -253,7 +238,9 @@ misc:
       maxCapacity: 20
   grants:
     - grant: queue:create-task:highest:proj-misc/ci
-      to: repo:github.com/mozilla/*
+      to:
+        - repo:github.com/mozilla/*
+        - repo:github.com/marco-c/taskcluster_yml_validator:*
 
 git-cinnabar:
   adminRoles:


### PR DESCRIPTION
The underscores in the project name are incompatible with the GCP
provider.  This project only runs simple lint/CI, so misc is sufficient,
rather than renaming the project to `tcymlvalidator` or the like.