### PR TITLE
Add repo admin for git-cinnabar

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -164,8 +164,8 @@ firefoxreality:
   adminRoles:
     - github-org-admin:MozillaReality
   repos:
-    - github.com/MozillaReality/FirefoxReality
-    - github.com/MozillaReality/FirefoxRealityPC
+    - github.com/MozillaReality/FirefoxReality:*
+    - github.com/MozillaReality/FirefoxRealityPC:*
   workerPools:
     ci-linux:
       owner: nobody@mozilla.com
@@ -259,7 +259,7 @@ git-cinnabar:
   adminRoles:
     - login-identity:github/1038527|glandium
   repos:
-    - github.com/glandium/git-cinnabar
+    - github.com/glandium/git-cinnabar:*
   workerPools:
     ci:
       type: standard_gcp_docker_worker

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -258,6 +258,8 @@ misc:
 git-cinnabar:
   adminRoles:
     - login-identity:github/1038527|glandium
+  repos:
+    - github.com/glandium/git-cinnabar
   workerPools:
     ci:
       type: standard_gcp_docker_worker

--- a/generate/projects.py
+++ b/generate/projects.py
@@ -47,6 +47,9 @@ async def update_resources(resources):
                 description="",
                 scopes=['assume:project-admin:{}'.format(project.name)]))
         if project.repos:
+            for repo in project.repos:
+                assert repo.endswith('/*') or repo.endswith(':*'), \
+                    "project.repos should end with `/*` or `:*`, got {}".format(repo)
             resources.add(Role(
                 roleId='project-admin:{}'.format(project.name),
                 description="",


### PR DESCRIPTION
```diff
(sandbox) dustin@lamport ~/p/community-tc-config [cinnabar-repos] $ tc-admin diff --grep cinnabar                                                                                                                                                                                                                                                                           
--- current                                                                                                                                                                                                                                                                                                                                                                 
+++ generated
@@ -17,16 +17,24 @@ Client=project/git-cinnabar/worker-osx-10-11:
     clientId: project/git-cinnabar/worker-osx-10-11
     description:
       *DO NOT EDIT* - This resource is configured automatically.


     scopes:
       - queue:claim-work:proj-git-cinnabar/osx-10-11
       - queue:worker-id:proj-git-cinnabar/travis-*
+
+  Role=project-admin:git-cinnabar:
+    roleId: project-admin:git-cinnabar
+    description:
+      *DO NOT EDIT* - This resource is configured automatically.
+
+
+    scopes: - assume:repo-admin:github.com/glandium/git-cinnabar

   Role=repo:github.com/glandium/git-cinnabar:branch:*:
     roleId: repo:github.com/glandium/git-cinnabar:branch:*
     description:
       *DO NOT EDIT* - This resource is configured automatically.


     scopes:
```