### PR TITLE
Bug 1574668 - add a 'wpt' project

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -297,6 +297,19 @@ git-cinnabar:
         - repo:github.com/glandium/git-cinnabar:branch:*
         - repo:github.com/glandium/git-cinnabar:tag:*
 
+wpt:
+  adminRoles:
+    - github-team:web-platform-tests/admins
+  workerPools:
+    ci:
+      type: standard_gcp_docker_worker
+      maxCapacity: 40
+  repos:
+    - github.com/web-platform-tests/*
+  grants:
+    - grant: queue:create-task:highest:proj-wpt/ci
+      to: repo:github.com/web-platform-tests/wpt:*
+
 relman:
   adminRoles:
     - github-team:mozilla/release-management


### PR DESCRIPTION
This project just has its own (dedicated) docker-worker worker pool.  As configured, this will run in GCP, but the effect should be pretty similar to the existing AWS worker type.

We can add to `adminRoles` as necessary -- if there's individual GitHub users who should have access, or GitHub teams, or all org admins of the wpt org.