### PR TITLE
Bug 1575648 - migrate webrender to taskcluster community deployment

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -616,9 +616,3 @@ webrender:
       to:
         - repo:github.com/servo/webrender:*
         - repo:github.com/staktrace/webrender:*
-    - grant:
-        - assume:worker-pool:proj-webrender/macos
-        - auth:sentry:generic-worker
-        - secrets:get:worker-pool:proj-webrender/*
-      to:
-        - project/webrender/macos

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -151,7 +151,7 @@ servo:
   adminRoles: [github-team:servo/taskcluster-admins]
   externallyManaged: true
   repos: 
-    - github.com/servo/*
+    - github.com/servo/servo:*
   workerPools:
     ci:
       owner: nobody@mozilla.com
@@ -333,3 +333,38 @@ relman:
         - docker-worker:capability:privileged
         - queue:route:statuses
       to: repo:github.com/mozilla/code-review:*
+
+webrender:
+  adminRoles:
+    - login-identity:github/27658|jdm
+    - login-identity:github/332653|jrmuizel
+    - login-identity:github/485789|staktrace
+    - login-identity:github/39062770|gw3583
+  repos:
+    - github.com/servo/webrender:*
+    - github.com/staktrace/webrender:*
+  workerPools:
+    ci-linux:
+      owner: kats@mozilla.com
+      emailOnError: false
+      type: standard_gcp_docker_worker
+      minCapacity: 0
+      maxCapacity: 2
+  clients:
+    macos:
+      scopes:
+        - queue:claim-work:proj-webrender/ci-macos
+        - queue:worker-id:proj-webrender/*
+  grants:
+    - grant:
+        - queue:create-task:highest:proj-webrender/ci-linux
+        - queue:create-task:highest:proj-webrender/ci-macos
+      to:
+        - repo:github.com/servo/webrender:*
+        - repo:github.com/staktrace/webrender:*
+    - grant:
+        - assume:worker-pool:proj-webrender/macos
+        - auth:sentry:generic-worker
+        - secrets:get:worker-pool:proj-webrender/*
+      to:
+        - project/webrender/macos


### PR DESCRIPTION
See [bug 1575648](https://bugzil.la/1575648) for context.

I'm not entirely sure I've captured everything here, but I think this should get us most of the way.

# webrender project

## References

### .taskcluster.yml
  * https://github.com/servo/webrender/blob/master/.taskcluster.yml

### Repos
  * [github.com/servo/webrender](https://github.com/servo/webrender)
  * [github.com/staktrace/webrender](https://github.com/staktrace/webrender)

## taskcluster.net state

### Worker types
  * aws-provisioner-v1/github-worker
  * localprovisioner/webrender-ci-osx

### Clients
  * project/webrender-ci/macos
    * assume:worker-type:localprovisioner/webrender-ci-osx

### Roles
  * mozillians-group:webrender-ci
    * assume:project-admin:webrender-ci
  * project:webrender-ci:grants/github-repos
    * assume:github-admin:servo/webrender
  * project:webrender-ci:grants/workers
    * queue:quarantine-worker:localprovisioner/webrender-ci-osx/*
  * repo:github.com/servo/webrender:*
    * queue:create-task:high:localprovisioner/kats-*
    * queue:create-task:highest:localprovisioner/kats-*
    * queue:create-task:localprovisioner/kats-*
    * queue:create-task:low:localprovisioner/kats-*
    * queue:create-task:lowest:localprovisioner/kats-*
    * queue:create-task:medium:localprovisioner/kats-*
    * queue:create-task:very-high:localprovisioner/kats-*
    * queue:create-task:very-low:localprovisioner/kats-*
    * queue:create-task:high:localprovisioner/webrender-ci-*
    * queue:create-task:highest:localprovisioner/webrender-ci-*
    * queue:create-task:localprovisioner/webrender-ci-*
    * queue:create-task:low:localprovisioner/webrender-ci-*
    * queue:create-task:lowest:localprovisioner/webrender-ci-*
    * queue:create-task:medium:localprovisioner/webrender-ci-*
    * queue:create-task:very-high:localprovisioner/webrender-ci-*
    * queue:create-task:very-low:localprovisioner/webrender-ci-*
  * repo:github.com/staktrace/webrender:*
    * assume:repo:github.com/webrender/webrender:*
    * queue:create-task:high:localprovisioner/kats-*
    * queue:create-task:highest:localprovisioner/kats-*
    * queue:create-task:localprovisioner/kats-*
    * queue:create-task:low:localprovisioner/kats-*
    * queue:create-task:lowest:localprovisioner/kats-*
    * queue:create-task:medium:localprovisioner/kats-*
    * queue:create-task:very-high:localprovisioner/kats-*
    * queue:create-task:very-low:localprovisioner/kats-*
    * queue:create-task:high:localprovisioner/webrender-ci-osx
    * queue:create-task:highest:localprovisioner/webrender-ci-osx
    * queue:create-task:localprovisioner/webrender-ci-osx
    * queue:create-task:low:localprovisioner/webrender-ci-osx
    * queue:create-task:lowest:localprovisioner/webrender-ci-osx
    * queue:create-task:medium:localprovisioner/webrender-ci-osx
    * queue:create-task:very-high:localprovisioner/webrender-ci-osx
    * queue:create-task:very-low:localprovisioner/webrender-ci-osx
  * repo:hg.mozilla.org/mozilla-central:*
    * secrets:get:project/webrender-ci/wrupdater-github-token
  * worker-type:localprovisioner/webrender-ci-osx
    * assume:worker-id:*
    * auth:sentry:generic-worker
    * queue:worker-id:*

## community-tc.services.mozilla.com state

### Worker types

* [proj-webrender/ci-linux](https://community-tc.services.mozilla.com/worker-manager/proj-webrender%2Fci-linux)
* proj-webrender/ci-macos

### Clients

* [project/webrender/macos](https://community-tc.services.mozilla.com/auth/clients/project%2Fwebrender%2Fmacos)
  * queue:claim-work:proj-webrender/ci-macos
  * queue:worker-id:proj-webrender/*

### Roles
 
* [project-admin:webrender](https://community-tc.services.mozilla.com/auth/roles/project-admin%3Awebrender)
  * assume:hook-id:project-webrender/*
  * assume:project-admin:webrender
  * assume:project:webrender:*
  * assume:repo-admin:github.com/servo/webrender:*
  * assume:repo-admin:github.com/staktrace/webrender:*
  * assume:repo:github.com/servo/webrender:*
  * assume:repo:github.com/staktrace/webrender:*
  * auth:create-client:project/webrender/*
  * auth:create-role:hook-id:project-webrender/*
  * auth:create-role:project:webrender:*
  * auth:create-role:repo:github.com/servo/webrender:*
  * auth:create-role:repo:github.com/staktrace/webrender:*
  * auth:delete-client:project/webrender/*
  * auth:delete-role:hook-id:project-webrender/*
  * auth:delete-role:project:webrender:*
  * auth:delete-role:repo:github.com/servo/webrender:*
  * auth:delete-role:repo:github.com/staktrace/webrender:*
  * auth:disable-client:project/webrender/*
  * auth:enable-client:project/webrender/*
  * auth:reset-access-token:project/webrender/*
  * auth:update-client:project/webrender/*
  * auth:update-role:hook-id:project-webrender/*
  * auth:update-role:project:webrender:*
  * auth:update-role:repo:github.com/servo/webrender:*
  * auth:update-role:repo:github.com/staktrace/webrender:*
  * docker-worker:cache:*
  * generic-worker:cache:*
  * hooks:modify-hook:project-webrender/*
  * hooks:trigger-hook:project-webrender/*
  * index:insert-task:project.webrender.*
  * project:webrender:*
  * purge-cache:proj-webrender/*
  * queue:create-task:high:proj-webrender/*
  * queue:create-task:highest:proj-webrender/*
  * queue:create-task:low:proj-webrender/*
  * queue:create-task:lowest:proj-webrender/*
  * queue:create-task:medium:proj-webrender/*
  * queue:create-task:very-high:proj-webrender/*
  * queue:create-task:very-low:proj-webrender/*
  * queue:get-artifact:project/webrender/*
  * queue:quarantine-worker:proj-webrender/*
  * queue:route:index.project.webrender.*
  * secrets:get:project/webrender/*
  * secrets:get:worker-pool:proj-webrender/*
  * secrets:set:project/webrender/*
  * secrets:set:worker-pool:proj-webrender/*
  * worker-manager:create-worker-pool:proj-webrender/*
  * worker-manager:create-worker-type:proj-webrender/*
  * worker-manager:create-worker:proj-webrender/*
  * worker-manager:update-worker-pool:proj-webrender/*
  * worker-manager:update-worker-type:proj-webrender/*
* [repo:github.com/servo/webrender:*](https://community-tc.services.mozilla.com/auth/roles/repo%3Agithub.com%2Fservo%2Fwebrender%3A*)
  * assume:repo:github.com/servo/webrender:*
  * queue:create-task:highest:proj-webrender/ci-linux
  * queue:create-task:highest:proj-webrender/ci-macos