### PR TITLE
replace redo project with releng project

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -206,20 +206,21 @@ firefoxreality:
     - grant: secrets:get:project/firefoxreality/frpc/github-deploy-key
       to: repo:github.com/MozillaReality/FirefoxRealityPC:branch:*
 
-redo:
-  adminRoles: []
+releng:
+  adminRoles:
+    - github-team:mozilla-releng/releng
   repos:
-    - github.com/mozilla-releng/redo:*
+    - github.com/mozilla-releng/*
   workerPools:
     ci:
-      owner: bhearsum@mozilla.com
+      owner: release@mozilla.com
       emailOnError: false
       type: standard_gcp_docker_worker
       minCapacity: 0
-      maxCapacity: 2
+      maxCapacity: 10
   grants:
-    - grant: queue:create-task:highest:proj-redo/ci
-      to: repo:github.com/mozilla-releng/redo:*
+    - grant: queue:create-task:highest:proj-releng/*
+      to: repo:github.com/mozilla-releng/*
 
 taskcluster_yml_validator:
   adminRoles:


### PR DESCRIPTION
- the redo project is a releng project, but there are others, i.e. maven-lambda
- this lets us share the worker-pool across those projects

- [x] delete the scopes/roles for `redo` after replacing the worker-pool in its repo