### PR TITLE
Bug 1593165 - grant glandium access d-w interactive sessions

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -297,6 +297,12 @@ git-cinnabar:
         - repo:github.com/glandium/git-cinnabar:branch:*
         - repo:github.com/glandium/git-cinnabar:tag:*
 
+    # glandium gets permission to access interactive sessions
+    - grant:
+        - queue:get-artifact:private/docker-worker/*
+      to:
+        - login-identity:github/1038527|glandium
+
 wpt:
   adminRoles:
     - github-team:web-platform-tests/admins


### PR DESCRIPTION
This was "accidentally" granted to team_moco in the old deployment (by virtue of granting `queue:get-artifact:private/*`).  I don't want to grant it too widely in the community deployment -- I'd rather wait until we have a better interactive story to support it at all.