### PR TITLE
Grant `queue:scheduler-id:taskcluster-github` to servo

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -189,7 +189,13 @@ servo:
       maxCapacity: 6
   grants:
     - grant:
+        # this is the scheduler-id for basically everything in this deployment
+        - queue:scheduler-id:taskcluster-github
+
+        # notification
         - queue:route:notify.irc-channel.#servo.*
+
+        # treeherder submission
         - queue:route:tc-treeherder-staging.v2._/servo-*
         - queue:route:tc-treeherder.v2._/servo-*
       # Grant to admins, purpose-specific roles are externally managed


### PR DESCRIPTION
...to support making hooks that use this schedulerId