### PR TITLE
use n1- instances for servo

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -179,14 +179,14 @@ servo:
       owner: servo-ops@mozilla.com
       emailOnError: false
       type: standard_gcp_docker_worker
-      machineType: "zones/{zone}/machineTypes/n2-highcpu-16"
+      machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       minCapacity: 2
       maxCapacity: 20
     docker-untrusted:
       owner: servo-ops@mozilla.com
       emailOnError: false
       type: standard_gcp_docker_worker
-      machineType: "zones/{zone}/machineTypes/n2-highcpu-16"
+      machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       minCapacity: 0
       maxCapacity: 6
   grants:


### PR DESCRIPTION
Because of https://bugzilla.mozilla.org/show_bug.cgi?id=1593792 and also 

`<SimonSapin> There are also errors like: Invalid value for field 'resource.machineType': 'zones/us-east4-a/machineTypes/n2-highcpu-16'. Machine type with name 'n2-highcpu-16' does not exist in zone 'us-east4-a'.`