### PR TITLE
Request mork disk space for Servo workers

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -180,6 +180,7 @@ servo:
       emailOnError: false
       type: standard_gcp_docker_worker
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
+      diskSizeGb: 100
       minCapacity: 2
       maxCapacity: 20
     docker-untrusted:
@@ -187,6 +188,7 @@ servo:
       emailOnError: false
       type: standard_gcp_docker_worker
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
+      diskSizeGb: 100
       minCapacity: 0
       maxCapacity: 6
   grants:


### PR DESCRIPTION
https://community-tc.services.mozilla.com/tasks/UxQR1tHSRN6imKedMGQGsQ/ failed twice in a row with an error message that *might* indicate low disk space.