### PR TITLE
update taskcluster project docker_worker_gcp image

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -52,6 +52,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       type: standard_gcp_docker_worker
+      image: projects/taskcluster-imaging/global/images/docker-worker-gcp-googlecompute-2019-11-04t22-31-35z
       minCapacity: 1
       maxCapacity: 20
       privileged: true


### PR DESCRIPTION
changes:
- includes lz4 per https://github.com/taskcluster/monopacker/pull/27

The idea is to test the taskcluster projects with this image, if things seem OK we'll replace the default.