### PR TITLE
Grant task management to Servo through project admin role instead of github team role

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -147,4 +147,4 @@
     - github-org-admin:MozillaReality
 
     # for servo
-    - github-team:servo/taskcluster-admins
+    - project-admin:servo


### PR DESCRIPTION
It’s not terribly important. Project admin is what I’ve been granting to laptop / CLI clients.