### PR TITLE
Add relman secrets

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -399,6 +399,23 @@ relman:
       type: standard_gcp_docker_worker
       minCapacity: 1
       maxCapacity: 50
+  secrets:
+    bugbug/deploy: true
+    bugbug/integration: true
+    bugbug/production: true
+    bugbug/testing: true
+    bugzilla-dashboard-backend/deploy-production: true
+    bugzilla-dashboard-backend/deploy-testing: true
+    code-coverage/deploy-production: true
+    code-coverage/deploy-testing: true
+    code-coverage/dev: true
+    code-coverage/runtime-production: true
+    code-coverage/runtime-testing: true
+    code-review/deploy-dev: true
+    code-review/deploy-production: true
+    code-review/deploy-testing: true
+    microannotate/deploy: true
+    taskboot/deploy: true
   grants:
     - grant: queue:create-task:highest:proj-relman/ci
       to:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -432,9 +432,34 @@ relman:
         - secrets:get:project/relman/bugbug/integration
       to: repo:github.com/mozilla/bugbug:*
     - grant:
+        - assume:project:relman:bugbug/deploy
+      to: repo:github.com/mozilla/bugbug:tag:*
+    - grant:
+        - assume:hook-id:project-relman/bugbug
+        - assume:hook-id:project-relman/bugbug-annotate
+        - assume:hook-id:project-relman/bugbug-checks
+        - assume:hook-id:project-relman/bugbug-classify-patch
+        - hooks:modify-hook:project-relman/bugbug
+        - hooks:modify-hook:project-relman/bugbug-annotate
+        - hooks:modify-hook:project-relman/bugbug-checks
+        - hooks:modify-hook:project-relman/bugbug-classify-patch
+        - queue:route:notify.pulse.route.project.relman.bugbug.deploy_ending.*
+        - queue:route:project.relman.bugbug.deploy_ending
+        - queue:route:project.relman.bugbug.deploy_ending.*
+        - secrets:get:project/relman/bugbug/deploy
+      to: project:relman:bugbug/deploy
+    - grant:
         - docker-worker:capability:privileged
         - queue:route:statuses
       to: repo:github.com/mozilla/task-boot:*
+    - grant:
+        - assume:project:relman:taskboot/release
+      to:
+        - repo:github.com/mozilla/task-boot:branch:master
+        - repo:github.com/mozilla/task-boot:tag:*
+    - grant:
+        - secrets:get:project/relman/taskboot/deploy
+      to: project:relman:taskboot/release
     - grant:
         - docker-worker:capability:privileged
         - queue:route:statuses


### PR DESCRIPTION
This does not include any `runtime` secrets (other than bugbug) which will only exist in the firefox-ci deployment. We have decided to run bugbug entirely in the community cluster iiuc.