### PR TITLE
deepspeech: add ssh-key secrets, allow project-admins to get

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -636,8 +636,12 @@ deepspeech:
         - repo:github.com/mozilla/tensorflow:*
     - grant:
         - generic-worker:allow-rdp:proj-deepspeech/*
+        - secrets:get:project/deepspeech/ssh-keys/*
       to:
         - project-admin:deepspeech
+  secrets:
+    ssh-keys/deepspeech-win: true
+    ssh-keys/deepspeech-win-b: true
 
 webrender:
   adminRoles:


### PR DESCRIPTION
- [x] I've already added these secrets manually