### PR TITLE
Admins get access to private/docker-worker artifacts

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -130,6 +130,7 @@
     - queue:schedule-task:taskcluster-github/*
     - queue:rerun-task:taskcluster-github/*
     - queue:scheduler-id:taskcluster-github
+    - queue:get-artifact:private/docker-worker/*
   to:
     # note, specific users are temporary until mozilla org grants permissions
     # to read teams, https://bugzilla.mozilla.org/show_bug.cgi?id=1593632

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -360,12 +360,6 @@ git-cinnabar:
         - repo:github.com/glandium/git-cinnabar:branch:*
         - repo:github.com/glandium/git-cinnabar:tag:*
 
-    # glandium gets permission to access interactive sessions
-    - grant:
-        - queue:get-artifact:private/docker-worker/*
-      to:
-        - login-identity:github/1038527|glandium
-
 wpt:
   adminRoles:
     - github-team:web-platform-tests/admins


### PR DESCRIPTION
(already applied)