### PR TITLE
Make relman externally managed

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -382,6 +382,7 @@ wpt:
 relman:
   adminRoles:
     - github-team:mozilla/sallt
+  externallyManaged: true # bugbug deploys some hooks into this space
   repos:
     - github.com/mozilla/bugbug:*
     - github.com/mozilla/microannotate:*


### PR DESCRIPTION
This is to support bugbug deploying its own hooks