### PR TITLE
add scheduler-id '-' to release-metrics hook

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -372,6 +372,11 @@ misc:
         - queue:scheduler-id:-
       to:
         - hook-id:project-misc/jcristau-fx-release-metrics
+    # allow jcristau to trigger the release-metrics hook directly
+    - grant:
+        - hooks:trigger-hook:project-misc/jcristau-fx-release-metrics
+      to:
+        - login-identity:github/3703806|jcristau
 
 git-cinnabar:
   adminRoles:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -369,6 +369,7 @@ misc:
         - queue:create-task:highest:proj-misc/ci
         - queue:route:index.project.misc.jcristau.*
         - queue:route:notify.email.jcristau@mozilla.com.*
+        - queue:scheduler-id:-
       to:
         - hook-id:project-misc/jcristau-fx-release-metrics
 


### PR DESCRIPTION
This is causing the hook to fail.  I've already deployed.