### PR TITLE
Add queue:scheduler-id:taskcluster-github to wpt

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -439,6 +439,7 @@ wpt:
     - grant:
         - queue:create-task:highest:proj-wpt/ci
         - docker-worker:capability:privileged
+        - queue:scheduler-id:taskcluster-github
       to: repo:github.com/web-platform-tests/wpt:*
 
 relman:


### PR DESCRIPTION
Add `queue:scheduler-id:taskcluster-github` grants to `repo:github.com/web-platform-tests/wpt:*` to allow decision task to schedule tasks.