### PR TITLE
Use assume:worker-{pool,id} for worker clients

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -52,6 +52,7 @@
 #     <clientId-suffix>:  # suffix after `project/<project-name>/`
 #       scopes: [ .. ]
 #       description: ..   # optional
+#     # when creating a client for a standalone worker, use `assume:worker-id:..` and `assume:worker-pool:..`.
 #
 #   grants:  # (same format as grants.yml)
 #
@@ -394,12 +395,12 @@ git-cinnabar:
   clients:
     worker-osx-10-10:
       scopes:
-        - queue:claim-work:proj-git-cinnabar/osx-10-10
-        - queue:worker-id:proj-git-cinnabar/travis-*
+        - assume:worker-pool:proj-git-cinnabar/osx-10-10
+        - assume:worker-id:proj-git-cinnabar/travis-*
     worker-osx-10-11:
       scopes:
-        - queue:claim-work:proj-git-cinnabar/osx-10-11
-        - queue:worker-id:proj-git-cinnabar/travis-*
+        - assume:worker-pool:proj-git-cinnabar/osx-10-11
+        - assume:worker-id:proj-git-cinnabar/travis-*
   grants:
     - grant:
         - queue:create-task:highest:proj-git-cinnabar/ci
@@ -794,8 +795,8 @@ webrender:
   clients:
     macos:
       scopes:
-        - queue:claim-work:proj-webrender/ci-macos
-        - queue:worker-id:proj-webrender/*
+        - assume:worker-pool:proj-webrender/ci-macos
+        - assume:worker-id:proj-webrender/*
   grants:
     - grant:
         - queue:create-task:highest:proj-webrender/ci-linux


### PR DESCRIPTION
This should have no effect -- I've changed "queue:claim-work:<workerPoolId>" to "[assume:worker-pool:<workerPoolId>](https://community-tc.services.mozilla.com/auth/roles/worker-pool%3A*)" which implies the former scope.  Similarly for "[assume:worker-id:<workerGroup>/<workerId>](https://community-tc.services.mozilla.com/auth/roles/worker-id%3A*)".

/cc @jgraham @glandium 