### PR TITLE
Increase wpt maxCapacity to 80

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -430,7 +430,7 @@ wpt:
     ci:
       type: standard_gcp_docker_worker
       privileged: true
-      maxCapacity: 40
+      maxCapacity: 80
   repos:
     - github.com/web-platform-tests/*
   grants:


### PR DESCRIPTION
The project is currently saturating the 40 worker pool and PRs are frequently waiting on Taskcluster c.f. https://github.com/web-platform-tests/wpt/issues/20256