### PR TITLE
Bug 1583990 - manage secrets with values from passwordstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ Repositories are granted scopes via the [Taskcluster-github scheme](https://docs
 Each repository is associated with a project, and scopes granted to the repository should be associated with that project.
 This occurs within `config/projects.yml`.
 
-### Externally Managed Projects
+### Secrets
+
+The tool can manage secrets directly, but this requires access to secret values, and is thus limited to a smaller group of people: the Taskcluster team.
+Those people use `--with-secrets`, which automatically reads from the team's password storage repository.
+
+In general, per-project secrets can either be managed by this tool, or managed directly by the project admins.
+See the comments in `projects.yml` for details.
+
+### Externally Managed Projects and Resources
 
 This respository manages all resources in the deployment *except* those associated with "externally managed" projects.
 Projects that manage their own resources, either by hand or via their own automation, should have the `externallyManaged` attribute set in `config/projects.yml`, otherwise the next run of `tc-admin apply` will delete the project's resources!

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -35,10 +35,16 @@
 #       ..: ..  # arguments to that function
 #
 #   secrets:
-#     # secrets are just asserted to exist; at the moment this repo does not support
-#     # managing secret *values*.  However, this is a great place to comment on the
-#     # content of the secret.
-#     <name-suffix>: true  # suffix after `project/<project-name>/`
+#     # Secrets associated with this project, suffixed to `project/<project-name>/`.
+#     # These secrets can be managed externally by setting the value to `true`:
+#     <name-suffix>: true
+#     # or can be given an explicit value, with interpolation of values from the
+#     # secret-values backend using `$<name>`:
+#     <name-suffix>:
+#       someservice:
+#         hostname: someservice.com
+#         username: $someservice-username
+#         password: $someservice-password
 #
 #   hooks:
 #     # hooks, keyed by hookId.
@@ -179,8 +185,9 @@ taskcluster:
     testing/codecov: true
     # client_id/access_token for project/taskcluster/testing/docker-worker/ci-creds
     testing/docker-worker/ci-creds: true
-    # AZURE_ACCOUNT / AZURE_ACCOUNT_KEY for a testing account
-    testing/azure: true
+    testing/azure:
+      AZURE_ACCOUNT: $taskcluster-azure-account
+      AZURE_ACCOUNT_KEY: $taskcluster-azure-account-key
     # additional secrets for services' tests (see services/<service>/test/helper.js)
     testing/taskcluster-auth: true
     testing/taskcluster-notify: true

--- a/generate/__init__.py
+++ b/generate/__init__.py
@@ -11,6 +11,7 @@ import sys
 from tcadmin.appconfig import AppConfig
 
 from . import projects, grants
+from .secret_values import SecretValues
 
 
 async def update_resources(resources):
@@ -26,12 +27,9 @@ async def update_resources(resources):
     em_bar = "|".join(externally_managed_patterns)
     resources.manage(re.compile(r"(?!{}).*".format(em_bar)))
 
+    secret_values = None
     if AppConfig.current().options.get("with_secrets"):
-        print(
-            "Use --without-secrets; secret management is not yet supported",
-            file=sys.stderr,
-        )
-        os._exit(1)
+        secret_values = SecretValues()
 
-    await projects.update_resources(resources)
-    await grants.update_resources(resources)
+    await projects.update_resources(resources, secret_values)
+    await grants.update_resources(resources, secret_values)

--- a/generate/grants.py
+++ b/generate/grants.py
@@ -36,6 +36,6 @@ class Grants(ConfigList):
         return cls(cls.Item(**g) for g in project.grants)
 
 
-async def update_resources(resources):
+async def update_resources(resources, secret_values):
     for grant in await Grants.load(loader):
         grant.update_resources(resources)

--- a/generate/secret_values.py
+++ b/generate/secret_values.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+import sys
+import yaml
+
+PASSWORDSTORE_NAME = "community-tc/secret-values.yml"
+
+
+class SecretValues:
+    """A container for secret values.  This is loaded only when --with-secrets,
+    and requires `passwordstore` support."""
+
+    def __init__(self):
+        print("Fetching secrets with passwordstore", file=sys.stderr)
+        secret_values_yml = subprocess.check_output(["pass", PASSWORDSTORE_NAME])
+        self.values = yaml.safe_load(secret_values_yml)
+
+    def get(self, name, default=None):
+        return self.values.get(name, default)
+
+    def __getitem__(self, name):
+        return self.values[name]
+
+    def render(self, template):
+        """
+        Replace '$secretname' with that secret value in the given recursive data structure.  Values
+        that begin with `$` can be escaped with `$$`.
+        """
+
+        def recur(value):
+            if isinstance(value, str):
+                if value.startswith("$"):
+                    if value.startswith("$$"):
+                        return value[1:]
+                    else:
+                        return self[value[1:]]
+            elif isinstance(value, list):
+                return [recur(v) for v in value]
+            elif isinstance(value, dict):
+                return {k: recur(v) for k, v in value.items()}
+            return value
+
+        return recur(template)


### PR DESCRIPTION
I sort of threw this together.  If this is the wrong approach, let me know.

For the most part (except for our azure secret), this leaves existing secrets externally managed.  That's probably best for most projects other than taskcluster, anyway.

What this will really help with is worker-pool secrets -- those are now managed automatically.