### PR TITLE
Bug 1587554 - part 1: add generic-worker CI roles and clients

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -186,14 +186,14 @@ taskcluster:
         - generic-worker:os-group:test-provisioner/*
         - generic-worker:run-as-administrator:test-provisioner/*
         - queue:cancel-task:test-scheduler/*
-        - queue:claim-work:test-provisioner/*
+        - assume:worker-pool:test-provisioner/*
         - queue:create-artifact:public/*
         - queue:create-task:test-provisioner/*
         - queue:get-artifact:SampleArtifacts/_/X.txt
         - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
         - queue:get-artifact:SampleArtifacts/b/c/d.jpg
         - queue:resolve-task
-        - queue:worker-id:test-worker-group/*"
+        - assume:worker-id:test-worker-group/*"
       to: project:taskcluster:generic-worker-tester
 
     - grant:
@@ -217,8 +217,8 @@ taskcluster:
     # Client for workerpool proj-taskcluster/gw-ci-macos-staging.
     generic-worker/ci-macos-staging:
       scopes:
-        - queue:claim-work:proj-taskcluster/gw-ci-macos-staging
-        - queue:worker-id:proj-taskcluster/*
+        - assume:worker-pool:proj-taskcluster/gw-ci-macos-staging
+        - assume:worker-id:proj-taskcluster/*
     # A client whose clientId and accessToken are stored in taskcluster secret
     # `repo:github.com/taskcluster/generic-worker` and used by commands in
     # generic-worker's .taskcluster.yml to create production tasks that are

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -179,7 +179,6 @@ taskcluster:
         - auth:create-client:project/taskcluster:generic-worker-tester/TestReclaimCancelledTask
         - auth:create-client:project/taskcluster:generic-worker-tester/TestResolveResolvedTask
         - auth:sentry:generic-worker-tests
-        - auth:webhooktunnel
         - generic-worker:cache:banana-cache
         - generic-worker:cache:devtools-app
         - generic-worker:cache:test-modifications
@@ -213,8 +212,8 @@ taskcluster:
     # Client for workerpool proj-taskcluster/gw-ci-macos.
     generic-worker/ci-macos:
       scopes:
-        - queue:claim-work:proj-taskcluster/gw-ci-macos
-        - queue:worker-id:proj-taskcluster/*
+        - assume:worker-pool:proj-taskcluster/gw-ci-macos
+        - assume:worker-id:proj-taskcluster/*
     # Client for workerpool proj-taskcluster/gw-ci-macos-staging.
     generic-worker/ci-macos-staging:
       scopes:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -89,7 +89,7 @@ taskcluster:
       privileged: true
   grants:
     - grant:
-        - queue:create-task:highest:proj-taskcluster/ci
+        - queue:create-task:highest:proj-taskcluster/*
         # The account and secret for the Azure testing storage account.
         # This is secret but ok for use by PRs.
         - secrets:get:project/taskcluster/testing/azure
@@ -173,6 +173,36 @@ taskcluster:
     - grant: assume:project:taskcluster:smoketests
       to: github-team:taskcluster/smoketesters
 
+    - grant:
+        - assume:worker-id:test-worker-group/test-worker-id
+        - assume:worker-type:test-provisioner/*
+        - auth:create-client:project/taskcluster:generic-worker-tester/TestReclaimCancelledTask
+        - auth:create-client:project/taskcluster:generic-worker-tester/TestResolveResolvedTask
+        - auth:sentry:generic-worker-tests
+        - auth:webhooktunnel
+        - generic-worker:cache:banana-cache
+        - generic-worker:cache:devtools-app
+        - generic-worker:cache:test-modifications
+        - generic-worker:cache:unknown-issuer-app-cache
+        - generic-worker:os-group:test-provisioner/*
+        - generic-worker:run-as-administrator:test-provisioner/*
+        - queue:cancel-task:test-scheduler/*
+        - queue:claim-work:test-provisioner/*
+        - queue:create-artifact:public/*
+        - queue:create-task:test-provisioner/*
+        - queue:get-artifact:SampleArtifacts/_/X.txt
+        - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
+        - queue:get-artifact:SampleArtifacts/b/c/d.jpg
+        - queue:resolve-task
+        - queue:worker-id:test-worker-group/*"
+      to: project:taskcluster:generic-worker-tester
+
+    - grant:
+        - assume:project:taskcluster:generic-worker-tester
+        - generic-worker:cache:generic-worker-checkout
+        - secrets:get:repo:github.com/taskcluster/generic-worker
+      to: repo:github.com/taskcluster/generic-worker:*
+
   clients:
     smoketests:
       scopes:
@@ -180,6 +210,32 @@ taskcluster:
     docker-worker/ci:
       scopes:
         - assume:repo:github.com/taskcluster/docker-worker:*
+    # Client for workerpool proj-taskcluster/gw-ci-macos.
+    generic-worker/ci-macos:
+      scopes:
+        - queue:claim-work:proj-taskcluster/gw-ci-macos
+        - queue:worker-id:proj-taskcluster/*
+    # Client for workerpool proj-taskcluster/gw-ci-macos-staging.
+    generic-worker/ci-macos-staging:
+      scopes:
+        - queue:claim-work:proj-taskcluster/gw-ci-macos-staging
+        - queue:worker-id:proj-taskcluster/*
+    # A client whose clientId and accessToken are stored in taskcluster secret
+    # `repo:github.com/taskcluster/generic-worker` and used by commands in
+    # generic-worker's .taskcluster.yml to create production tasks that are
+    # then claimed and processed by the generic-worker build under test.
+    generic-worker/taskcluster-ci:
+      scopes:
+        - assume:project:taskcluster:generic-worker-tester
+    # A client whose accessToken is securely stored in travis-ci.org
+    # taskcluster/generic-worker project as encrypted environment variable
+    # TASKCLUSTER_ACCESS_TOKEN, and used by commands in generic-worker's
+    # .travis.yml to create production tasks that are then claimed and
+    # processed by the generic-worker build under test in travis-ci.org.
+    generic-worker/travis-ci:
+      scopes:
+        - assume:project:taskcluster:generic-worker-tester
+
   secrets:
     # codecov API token
     testing/codecov: true
@@ -197,6 +253,7 @@ taskcluster:
     # monopacker image baking secrets
     monopacker/gcloud_service_account: true
     monopacker/worker_secrets_yaml: true
+
 
 bors-ng:
   adminRoles: []


### PR DESCRIPTION
I've decided to split this up into several bite size parts that can be landed independently.

This first part adds generic-worker CI roles and clients.

The next part is a little more disruptive, but this part shouldn't have any surprises.

Thanks!