### PR TITLE
Bug1587554 part 2: restructure code/config to use image sets

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -47,9 +47,9 @@ generic-worker-ubuntu-17-10:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-000f78733862c228b
-      us-west-1: ami-0d2bc4a97a0aaa9d3
-      us-west-2: ami-00e7eeb8d7449b1ce
+      us-east-1: ami-00477f6d6e091167d
+      us-west-1: ami-004d920c923ee252d
+      us-west-2: ami-0cbc5f32c8bbb1ec9
   workerConfig:
     genericWorker:
       config:
@@ -60,7 +60,7 @@ generic-worker-ubuntu-17-10:
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
-            script: https://raw.githubusercontent.com/taskcluster/generic-worker/b61e0d09401b0f4c4a8f33a5e2eb239bb90dc7ac/worker_types/gwci-linux/bootstrap.sh
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/ba5c21e60957f5ed3395f848f975a7ae8b147252/worker_types/gwci-linux/bootstrap.sh
 
 generic-worker-ubuntu-17-10-staging:
   workerImplementation: generic-worker

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -1,3 +1,49 @@
+# Image Sets
+#
+# Worker Manager providers spawn worker instances for a given worker pool from
+# pre-created machine images whose image names are specified in the worker pool
+# definition. Some cloud providers (such as AWS) require region-specific
+# machine images. An image set represents the set of (equivalent) images for a
+# given cloud provider, together with associated worker config.
+#
+#
+# Format of imagesets.yml
+#
+# Each image set is keyed by a consice descriptive name, which is referenced
+# from projects.yml (`imageset` key).
+#
+# The format of the image set configuration is as follows:
+#
+# <image-set-name>:
+#   <cloud>:              <cloud> is the name of a @cloud annotated function in
+#                         `generate/workers.py` (`aws`/`gcp`). The value
+#                         underneath the key depends on the cloud (see below).
+#   workerImplementation: the name of a @worker_pool_type annotated function in
+#                         `generate/workers.py` (with `-`s replaced with `_`s)
+#                         e.g. `docker-worker`/`generic-worker`.
+#   workerConfig:         a dict to merge with generated workerConfig sections
+#                         in generated worker pool definitions.
+#
+#
+# AWS Image Sets
+#
+# AWS image sets must include the following:
+#
+# aws:
+#   amis:
+#     <region1>: <ami1>
+#     <region2>: <ami2>
+#     ...
+#
+#
+# Google (gcp) Image Sets
+#
+# Google image sets include a single image, specified as follows:
+#
+# gcp:
+#   image:                Fully qualified name of the machine image to spawn.
+#                         e.g. `projects/taskcluster-imaging/global/images/docker-worker-gcp-googlecompute-2019-11-04t22-31-35z`
+
 docker-worker:
   workerImplementation: docker-worker
   gcp:

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -43,7 +43,7 @@ generic-worker-win2012r2-staging:
             maintainer: pmoore@mozilla.com
             script: https://raw.githubusercontent.com/taskcluster/generic-worker/2509a1f8589b0b536186f5fe8f043385bf67197f/worker_types/win2012r2/bootstrap.ps1
 
-generic-worker-ubuntu-17-10:
+generic-worker-ubuntu-18-04:
   workerImplementation: generic-worker
   aws:
     amis:
@@ -62,13 +62,13 @@ generic-worker-ubuntu-17-10:
             maintainer: pmoore@mozilla.com
             script: https://raw.githubusercontent.com/taskcluster/generic-worker/ba5c21e60957f5ed3395f848f975a7ae8b147252/worker_types/gwci-linux/bootstrap.sh
 
-generic-worker-ubuntu-17-10-staging:
+generic-worker-ubuntu-18-04-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-01c4e6a2abb5d8c00
-      us-west-1: ami-02ff90fcf53c8481a
-      us-west-2: ami-01409a9fc7ad58082
+      us-east-1: ami-029a1539ae3ce69b0
+      us-west-1: ami-047fd83611b397644
+      us-west-2: ami-056c7a4b568d09255
   workerConfig:
     genericWorker:
       config:
@@ -79,7 +79,7 @@ generic-worker-ubuntu-17-10-staging:
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
-            script: https://raw.githubusercontent.com/taskcluster/generic-worker/122f90ed4c27f2abb0cd839e3944184312ad9590/worker_types/gwci-linux-beta/bootstrap.sh
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/ba5c21e60957f5ed3395f848f975a7ae8b147252/worker_types/gwci-linux-beta/bootstrap.sh
 
 deepspeech-win2012r2:
   workerImplementation: generic-worker

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -43,7 +43,7 @@ generic-worker-win2012r2-staging:
             maintainer: pmoore@mozilla.com
             script: https://raw.githubusercontent.com/taskcluster/generic-worker/2509a1f8589b0b536186f5fe8f043385bf67197f/worker_types/win2012r2/bootstrap.ps1
 
-generic-worker-linux:
+generic-worker-ubuntu-17-10:
   workerImplementation: generic-worker
   aws:
     amis:
@@ -62,7 +62,7 @@ generic-worker-linux:
             maintainer: pmoore@mozilla.com
             script: https://raw.githubusercontent.com/taskcluster/generic-worker/b61e0d09401b0f4c4a8f33a5e2eb239bb90dc7ac/worker_types/gwci-linux/bootstrap.sh
 
-generic-worker-linux-staging:
+generic-worker-ubuntu-17-10-staging:
   workerImplementation: generic-worker
   aws:
     amis:

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -1,0 +1,100 @@
+docker-worker:
+  workerImplementation: docker-worker
+  gcp:
+    image: projects/taskcluster-imaging/global/images/docker-worker-gcp-googlecompute-2019-11-04t22-31-35z
+
+generic-worker-win2012r2:
+  workerImplementation: generic-worker
+  aws:
+    amis:
+      us-east-1: ami-04ff4e4c220abce54
+      us-west-1: ami-070ee00d395f493d3
+      us-west-2: ami-02161407768d981ea
+  gcp:
+    image: projects/pmoore-dev/global/images/win2012r2-rzuhq8vonqvbsgvhdqsd
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: pmoore@mozilla.com
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/2509a1f8589b0b536186f5fe8f043385bf67197f/worker_types/win2012r2/bootstrap.ps1
+
+generic-worker-win2012r2-staging:
+  workerImplementation: generic-worker
+  aws:
+    amis:
+      us-east-1: ami-04ff4e4c220abce54
+      us-west-1: ami-070ee00d395f493d3
+      us-west-2: ami-02161407768d981ea
+  gcp:
+    image: projects/pmoore-dev/global/images/win2012r2-rzuhq8vonqvbsgvhdqsd
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: pmoore@mozilla.com
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/2509a1f8589b0b536186f5fe8f043385bf67197f/worker_types/win2012r2/bootstrap.ps1
+
+generic-worker-linux:
+  workerImplementation: generic-worker
+  aws:
+    amis:
+      us-east-1: ami-000f78733862c228b
+      us-west-1: ami-0d2bc4a97a0aaa9d3
+      us-west-2: ami-00e7eeb8d7449b1ce
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
+        livelogExecutable: /usr/local/bin/livelog
+        taskclusterProxyExecutable: /usr/local/bin/taskcluster-proxy
+        tasksDir: /home
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: pmoore@mozilla.com
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/b61e0d09401b0f4c4a8f33a5e2eb239bb90dc7ac/worker_types/gwci-linux/bootstrap.sh
+
+generic-worker-linux-staging:
+  workerImplementation: generic-worker
+  aws:
+    amis:
+      us-east-1: ami-01c4e6a2abb5d8c00
+      us-west-1: ami-02ff90fcf53c8481a
+      us-west-2: ami-01409a9fc7ad58082
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
+        livelogExecutable: /usr/local/bin/livelog
+        taskclusterProxyExecutable: /usr/local/bin/taskcluster-proxy
+        tasksDir: /home
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: pmoore@mozilla.com
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/122f90ed4c27f2abb0cd839e3944184312ad9590/worker_types/gwci-linux-beta/bootstrap.sh
+
+deepspeech-win2012r2:
+  workerImplementation: generic-worker
+  aws:
+    amis:
+      us-east-1: ami-00ac6736f325c15b8
+      us-west-1: ami-000f332719212504f
+      us-west-2: ami-032a6d4f0021ad2a9
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: alissy@mozilla.com
+            script: https://raw.githubusercontent.com/taskcluster/generic-worker/2509a1f8589b0b536186f5fe8f043385bf67197f/worker_types/deepspeech-win/bootstrap.ps1

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -31,6 +31,8 @@
 #     <worker-pool-name>:
 #       owner: ..
 #       emailOnError: ..
+#       instanceTypes: a dict, where each key is an instance type, and the
+#           value is the capacity per instance for that instance type.
 #       imageset: top level key from imagesets.yml
 #       cloud: cloud to deploy in ('aws' or 'gcp')
 #       ..: ..  # arguments to that function

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -93,10 +93,10 @@ taskcluster:
           allowPrivileged: true
 
     # gw-ci-* worker pools are for generic-worker CI
-    gw-ci-ubuntu-17-10:
+    gw-ci-ubuntu-18-04:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-17-10
+      imageset: generic-worker-ubuntu-18-04
       cloud: aws
       maxCapacity: 10
       workerConfig:
@@ -104,10 +104,10 @@ taskcluster:
           config:
             runTasksAsCurrentUser: true
 
-    gw-ci-ubuntu-17-10-staging:
+    gw-ci-ubuntu-18-04-staging:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-17-10-staging
+      imageset: generic-worker-ubuntu-18-04-staging
       cloud: aws
       maxCapacity: 10
       workerConfig:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -31,7 +31,8 @@
 #     <worker-pool-name>:
 #       owner: ..
 #       emailOnError: ..
-#       type: <name of a function in `generate/workers.py`)
+#       imageset: top level key from imagesets.yml
+#       cloud: cloud to deploy in ('aws' or 'gcp')
 #       ..: ..  # arguments to that function
 #
 #   secrets:
@@ -83,10 +84,59 @@ taskcluster:
     ci:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 1
       maxCapacity: 20
-      privileged: true
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
+
+    # gw-ci-* worker pools are for generic-worker CI
+    gw-ci-linux:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-linux
+      cloud: aws
+      maxCapacity: 10
+      workerConfig:
+        genericWorker:
+          config:
+            runTasksAsCurrentUser: true
+
+    gw-ci-linux-staging:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-linux-staging
+      cloud: aws
+      maxCapacity: 10
+      workerConfig:
+        genericWorker:
+          config:
+            runTasksAsCurrentUser: true
+
+    gw-ci-win2012r2:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-win2012r2
+      cloud: gcp
+      maxCapacity: 10
+      workerConfig:
+        genericWorker:
+          config:
+            runTasksAsCurrentUser: true
+
+    gw-ci-win2012r2-staging:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-win2012r2-staging
+      cloud: gcp
+      maxCapacity: 10
+      workerConfig:
+        genericWorker:
+          config:
+            runTasksAsCurrentUser: true
+
   grants:
     - grant:
         - queue:create-task:highest:proj-taskcluster/*
@@ -262,7 +312,8 @@ bors-ng:
     ci:
       owner: michael@notriddle.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 2
   grants:
@@ -278,7 +329,8 @@ servo:
     docker:
       owner: servo-ops@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       diskSizeGb: 100
       minCapacity: 2
@@ -286,7 +338,8 @@ servo:
     docker-untrusted:
       owner: servo-ops@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       diskSizeGb: 100
       minCapacity: 0
@@ -322,7 +375,8 @@ firefoxreality:
     ci-linux:
       owner: nobody@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 6
   grants:
@@ -367,7 +421,8 @@ releng:
     ci:
       owner: release@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
   grants:
@@ -387,7 +442,8 @@ misc:
     ci:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 1
       maxCapacity: 20
   hooks:
@@ -460,7 +516,8 @@ fuzzing:
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
   grants:
@@ -479,10 +536,12 @@ git-cinnabar:
     codecov: true
   workerPools:
     ci:
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       maxCapacity: 5
     win2012r2:
-      type: standard_aws_generic_worker_win2012r2
+      imageset: generic-worker-win2012r2
+      cloud: aws
       maxCapacity: 2
   clients:
     worker-osx-10-10:
@@ -521,9 +580,12 @@ wpt:
     - github-team:web-platform-tests/admins
   workerPools:
     ci:
-      type: standard_gcp_docker_worker
-      privileged: true
+      imageset: docker-worker
+      cloud: gcp
       maxCapacity: 80
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
   repos:
     - github.com/web-platform-tests/*
   grants:
@@ -551,21 +613,26 @@ relman:
     ci:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 1
       maxCapacity: 50
-      privileged: true
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
     compute-small:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 1
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-4"
     compute-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 1
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-8"
@@ -698,33 +765,26 @@ deepspeech:
     ci:
       owner: deepspeech@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 96
       machineType: "zones/{zone}/machineTypes/n1-standard-32"
     win:
       owner: deepspeech@mozilla.com
       emailOnError: false
-      type: aws_generic_worker_deepspeech_win
-      # these were generated from
-      # https://github.com/taskcluster/generic-worker/tree/94da59be253c63aea8f11e0f4929ab74f411f61b/worker_types/deepspeech-win
-      imageIds:
-        us-east-1: ami-00ac6736f325c15b8
-        us-west-1: ami-000f332719212504f
-        us-west-2: ami-032a6d4f0021ad2a9
-      minCapacity: 0
+      imageset: deepspeech-win2012r2
+      cloud: aws
+      instanceTypes:
+        m5d.2xlarge: 1
       maxCapacity: 16
     win-b:
       owner: deepspeech@mozilla.com
       emailOnError: false
-      type: aws_generic_worker_deepspeech_win
-      # these were generated from
-      # https://github.com/taskcluster/generic-worker/tree/94da59be253c63aea8f11e0f4929ab74f411f61b/worker_types/deepspeech-win
-      imageIds:
-        us-east-1: ami-00ac6736f325c15b8
-        us-west-1: ami-000f332719212504f
-        us-west-2: ami-032a6d4f0021ad2a9
-      minCapacity: 0
+      imageset: deepspeech-win2012r2
+      cloud: aws
+      instanceTypes:
+        m5d.2xlarge: 1
       maxCapacity: 16
   clients:
     worker/rpi3bp-1:
@@ -878,7 +938,8 @@ webrender:
     ci-linux:
       owner: kats@mozilla.com
       emailOnError: false
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 2
   clients:
@@ -905,7 +966,8 @@ l10n:
     - github.com/mozilla-l10n/*
   workerPools:
     ci:
-      type: standard_gcp_docker_worker
+      imageset: docker-worker
+      cloud: gcp
       maxCapacity: 5
   grants:
     - grant:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -93,7 +93,7 @@ taskcluster:
           allowPrivileged: true
 
     # gw-ci-* worker pools are for generic-worker CI
-    gw-ci-linux:
+    gw-ci-ubuntu-17-10:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-17-10
@@ -104,7 +104,7 @@ taskcluster:
           config:
             runTasksAsCurrentUser: true
 
-    gw-ci-linux-staging:
+    gw-ci-ubuntu-17-10-staging:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-17-10-staging
@@ -115,7 +115,7 @@ taskcluster:
           config:
             runTasksAsCurrentUser: true
 
-    gw-ci-win2012r2:
+    gw-ci-windows2012r2-amd64:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2
@@ -126,7 +126,7 @@ taskcluster:
           config:
             runTasksAsCurrentUser: true
 
-    gw-ci-win2012r2-staging:
+    gw-ci-windows2012r2-amd64-staging:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2-staging

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -96,7 +96,7 @@ taskcluster:
     gw-ci-linux:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-linux
+      imageset: generic-worker-ubuntu-17-10
       cloud: aws
       maxCapacity: 10
       workerConfig:
@@ -107,7 +107,7 @@ taskcluster:
     gw-ci-linux-staging:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-linux-staging
+      imageset: generic-worker-ubuntu-17-10-staging
       cloud: aws
       maxCapacity: 10
       workerConfig:

--- a/generate/imagesets.py
+++ b/generate/imagesets.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import attr
+
+from tcadmin.util.config import ConfigDict
+from .loader import loader
+
+
+class ImageSets(ConfigDict):
+
+    filename = "config/imagesets.yml"
+
+    @attr.s
+    class Item:
+        name = attr.ib(type=str)
+        workerImplementation = attr.ib(type=str)
+        aws = attr.ib(type=dict, factory=lambda: {})
+        gcp = attr.ib(type=dict, factory=lambda: {})
+        workerConfig = attr.ib(type=dict, factory=lambda: {})

--- a/generate/projects.py
+++ b/generate/projects.py
@@ -12,6 +12,7 @@ from tcadmin.util.config import ConfigDict
 from .loader import loader
 from .workers import build_worker_pool
 from .grants import Grants
+from .imagesets import ImageSets
 
 ADMIN_ROLE_PREFIXES = [
     "github-org-admin:",
@@ -83,6 +84,7 @@ class Projects(ConfigDict):
 
 async def update_resources(resources, secret_values):
     projects = await Projects.load(loader)
+    imageSets = await ImageSets.load(loader)
 
     for project in projects.values():
         for roleId in project.adminRoles:
@@ -112,10 +114,10 @@ async def update_resources(resources, secret_values):
             for name, worker_pool in project.workerPools.items():
                 worker_pool_id = "proj-{}/{}".format(project.name, name)
                 worker_pool["description"] = "Workers for " + project.name
+                image_set = imageSets[worker_pool["imageset"]]
                 worker_pool, secret = build_worker_pool(
-                    worker_pool_id, worker_pool, secret_values
+                    worker_pool_id, worker_pool, secret_values, image_set
                 )
-
                 if project.externallyManaged.manage_individual_resources():
                     resources.manage("WorkerPool={}".format(worker_pool_id))
                     if secret:

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -257,7 +257,11 @@ def aws(
             for instanceType, capacityPerInstance in instanceTypes.items():
                 # Instance type m3.2xlarge isn't available in us-east-1[a,f], so
                 # filter out that combination.
-                if instanceType == "m3.2xlarge" and az in ["us-east-1a", "us-east-1f", "us-west-2d"]:
+                if instanceType == "m3.2xlarge" and az in [
+                    "us-east-1a",
+                    "us-east-1f",
+                    "us-west-2d",
+                ]:
                     continue
                 launchConfig = {
                     "capacityPerInstance": capacityPerInstance,

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -249,9 +249,9 @@ def aws(
         groupId = AWS_SECURITY_GROUPS[region][securityGroup]
         for az, subnetId in AWS_SUBNETS[region].items():
             for instanceType, capacityPerInstance in instanceTypes.items():
-                # Instance type m3.2xlarge isn't available in us-east-1a, so
+                # Instance type m3.2xlarge isn't available in us-east-1[a,f], so
                 # filter out that combination.
-                if az == "us-east-1a" and instanceType == "m3.2xlarge":
+                if instanceType == "m3.2xlarge" and az in ["us-east-1a", "us-east-1f"]:
                     continue
                 launchConfig = {
                     "capacityPerInstance": capacityPerInstance,

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -257,7 +257,7 @@ def aws(
             for instanceType, capacityPerInstance in instanceTypes.items():
                 # Instance type m3.2xlarge isn't available in us-east-1[a,f], so
                 # filter out that combination.
-                if instanceType == "m3.2xlarge" and az in ["us-east-1a", "us-east-1f"]:
+                if instanceType == "m3.2xlarge" and az in ["us-east-1a", "us-east-1f", "us-west-2d"]:
                     continue
                 launchConfig = {
                     "capacityPerInstance": capacityPerInstance,

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -6,98 +6,62 @@
 
 from tcadmin.resources import WorkerPool, Secret
 
-TYPES = {}
+import hashlib
 
-AWS_PROVIDER = "community-tc-workers-aws"
-
-AWS_SUBNETS = {
-    "us-west-1": {
-        "us-west-1a": "subnet-0e43a99e9c865689e",
-        "us-west-1b": "subnet-0a5344f7003aede7c",
-    },
-    "us-west-2": {
-        "us-west-2a": "subnet-048a61782df5ba378",
-        "us-west-2b": "subnet-05053e2898fc744e9",
-        "us-west-2c": "subnet-036a0812d241733ef",
-        "us-west-2d": "subnet-0fc336d9e5934c913",
-    },
-    "us-east-1": {
-        "us-east-1a": "subnet-0ab0ba0d9836bb7ab",
-        "us-east-1b": "subnet-08c284e43fd180150",
-        "us-east-1c": "subnet-0034e6efd82d24939",
-        "us-east-1d": "subnet-05a055adc7a81adc0",
-        "us-east-1e": "subnet-03bbdcf0ec23f8caa",
-        "us-east-1f": "subnet-0cc340c5cf9346dcc",
-    },
-    "us-east-2": {
-        "us-east-2a": "subnet-05205c91d6a9f06e6",
-        "us-east-2b": "subnet-082be4d0d5e7e4d58",
-        "us-east-2c": "subnet-01eb0c6a5e15846db",
-    },
-}
-
-AWS_SECURITY_GROUPS = {
-    "us-west-1": {
-        "no-inbound": "sg-00c4014bc978171d5",
-        "docker-worker": "sg-0d2ff88f36a05b499",
-    },
-    "us-west-2": {
-        "no-inbound": "sg-0659c2937ecbe7254",
-        "docker-worker": "sg-0f8a656368c567425",
-    },
-    "us-east-1": {
-        "no-inbound": "sg-07f7d21a488e192c6",
-        "docker-worker": "sg-08fea1235cf66b102",
-    },
-    "us-east-2": {
-        "no-inbound": "sg-00a9d64b3595c5088",
-        "docker-worker": "sg-0388de36e2f30ced2  u",
-    },
-}
-
-DEFAULT_AWS_WIN2012_GENERIC_WORKER_IMAGES = {
-    # from https://bugzilla.mozilla.org/show_bug.cgi?id=1590910
-    "us-east-1": "ami-04ff4e4c220abce54",
-    "us-west-1": "ami-070ee00d395f493d3",
-    "us-west-2": "ami-02161407768d981ea",
-}
-
-GOOGLE_PROVIDER = "community-tc-workers-google"
-
-DEFAUlT_GOOGLE_DOCKER_WORKER_IMAGE = (
-    "projects/taskcluster-imaging/global/images/"
-    + "docker-worker-gcp-googlecompute-2019-11-04t22-31-35z"
-)
-
-GOOGLE_REGIONS_ZONES = {
-    "us-east1": ["b", "c", "d"],
-    "us-east4": ["a", "b", "c"],
-}
-
-GOOGLE_ZONES_REGIONS = [
-    ("{}-{}".format(region, zone), region)
-    for region, zones in sorted(GOOGLE_REGIONS_ZONES.items())
-    for zone in zones
-]
+CLOUD_FUNCS = {}
+WORKER_IMPLEMENTATION_FUNCS = {}
 
 
-def worker_pool_type(fn):
+def cloud(fn):
     """
-    Register a worker pool generator.  This function takes keyword arguments based on the
+    Register a cloud config generator. This function takes keyword arguments based on the
     configuration in `projects.yml`, plus `secret_values`, an instance of SecretValues or
-    None if running without secret.  It should return a dictionary with keys
+    None if running without secrets.  It should return a dictionary with keys
      - providerId - passed to worker-manager
      - config - passed to worker-manager
      - secret - content of the `worker-pool:<workerPoolId>` secret (optional)
     """
-
-    TYPES[fn.__name__] = fn
+    CLOUD_FUNCS[fn.__name__] = fn
     return fn
 
 
-def build_worker_pool(workerPoolId, cfg, secret_values):
+def worker_implementation(fn):
+    """
+    Register a worker implementation generator. This function takes keyword arguments
+    based on the configuration in `projects.yml`, plus `secret_values`, an instance of
+    SecretValues
+    or None if running without secrets.  It should return a dictionary with keys
+     - providerId - passed to worker-manager
+     - config - passed to worker-manager
+     - secret - content of the `worker-pool:<workerPoolId>` secret (optional)
+    """
+    WORKER_IMPLEMENTATION_FUNCS[fn.__name__] = fn
+    return fn
+
+
+def merge(source, destination):
+    """
+    Recursively merges a source and destination dict
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            merge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+
+
+def build_worker_pool(workerPoolId, cfg, secret_values, image_set):
     try:
-        wp = TYPES[cfg["type"]](secret_values=secret_values, **cfg)
+        wp = CLOUD_FUNCS[cfg["cloud"]](
+            secret_values=secret_values, image_set=image_set, **cfg,
+        )
+        wp = WORKER_IMPLEMENTATION_FUNCS[
+            image_set.workerImplementation.replace("-", "_")
+        ](secret_values=secret_values, image_set=image_set, wp=wp, **cfg,)
     except Exception as e:
         raise RuntimeError(
             "Error generating worker pool configuration for {}".format(workerPoolId)
@@ -123,21 +87,42 @@ def build_worker_pool(workerPoolId, cfg, secret_values):
     return workerpool, secret
 
 
-def base_google_config(
+@cloud
+def gcp(
     *,
+    image_set,
     minCapacity=0,
     maxCapacity=None,
     machineType="zones/{zone}/machineTypes/n1-standard-4",
+    diskSizeGb=50,
     **cfg,
 ):
     """
-    Build a base config for a Google instance
+    Build a worker pool in Google.
 
-      minCapacity: minimum capacity to run at any time (default 0)
-      maxCapacity: maximum capacity to run at any time (required)
+      image: image name (defaults to the standard image)
+      diskSizeGb: boot disk size, in Gb (defaults to 50)
+      privileged: true if this worker should allow privileged tasks (default false)
+      ..in addition to kwargs from base_google_config
     """
+
+    image = image_set.gcp["image"]
+
+    GOOGLE_PROVIDER = "community-tc-workers-google"
+
+    GOOGLE_REGIONS_ZONES = {
+        "us-east1": ["b", "c", "d"],
+        "us-east4": ["a", "b", "c"],
+    }
+
+    GOOGLE_ZONES_REGIONS = [
+        ("{}-{}".format(region, zone), region)
+        for region, zones in sorted(GOOGLE_REGIONS_ZONES.items())
+        for zone in zones
+    ]
+
     assert maxCapacity, "must give a maxCapacity"
-    return {
+    rv = {
         "providerId": GOOGLE_PROVIDER,
         "config": {
             "maxCapacity": maxCapacity,
@@ -165,21 +150,6 @@ def base_google_config(
             ],
         },
     }
-
-
-@worker_pool_type
-def standard_gcp_docker_worker(*, image=None, diskSizeGb=50, privileged=False, **cfg):
-    """
-    Build a standard docker-worker instance in Google.
-
-      image: image name (defaults to the standard image)
-      diskSizeGb: boot disk size, in Gb (defaults to 50)
-      privileged: true if this worker should allow privileged tasks (default false)
-      ..in addition to kwargs from base_google_config
-    """
-    if image is None:
-        image = DEFAUlT_GOOGLE_DOCKER_WORKER_IMAGE
-    rv = base_google_config(**cfg)
     for lc in rv["config"]["launchConfigs"]:
         lc["disks"][0]["initializeParams"] = {
             "sourceImage": image,
@@ -188,34 +158,20 @@ def standard_gcp_docker_worker(*, image=None, diskSizeGb=50, privileged=False, *
         lc["workerConfig"] = {
             "shutdown": {"enabled": True, "afterIdleSeconds": 900},
         }
-        if privileged:
-            lc.setdefault("workerConfig", {}).setdefault("dockerConfig", {})[
-                "allowPrivileged"
-            ] = True
-
-    if cfg["secret_values"]:
-        rv["secret"] = cfg["secret_values"].render(
-            {
-                "config": {
-                    "statelessHostname": {
-                        "secret": "$stateless-dns-secret",
-                        "domain": "taskcluster-worker.net",
-                    },
-                },
-            }
-        )
 
     return rv
 
 
-def base_aws_config(
+@cloud
+def aws(
     *,
     regions=None,
     imageIds=None,
-    instanceTypes=None,
+    instanceTypes={"m3.2xlarge": 1},
     securityGroup="no-inbound",
     minCapacity=0,
     maxCapacity=None,
+    image_set,
     **cfg,
 ):
     """
@@ -229,16 +185,74 @@ def base_aws_config(
       minCapacity: minimum capacity to run at any time (default 0)
       maxCapacity: maximum capacity to run at any time (required)
     """
+
     assert maxCapacity, "must give a maxCapacity"
-    assert regions, "must give regions"
-    assert imageIds, "must give imageIds"
     assert instanceTypes, "must give instanceTypes"
+
+    AWS_PROVIDER = "community-tc-workers-aws"
+
+    AWS_SUBNETS = {
+        "us-west-1": {
+            "us-west-1a": "subnet-0e43a99e9c865689e",
+            "us-west-1b": "subnet-0a5344f7003aede7c",
+        },
+        "us-west-2": {
+            "us-west-2a": "subnet-048a61782df5ba378",
+            "us-west-2b": "subnet-05053e2898fc744e9",
+            "us-west-2c": "subnet-036a0812d241733ef",
+            "us-west-2d": "subnet-0fc336d9e5934c913",
+        },
+        "us-east-1": {
+            "us-east-1a": "subnet-0ab0ba0d9836bb7ab",
+            "us-east-1b": "subnet-08c284e43fd180150",
+            "us-east-1c": "subnet-0034e6efd82d24939",
+            "us-east-1d": "subnet-05a055adc7a81adc0",
+            "us-east-1e": "subnet-03bbdcf0ec23f8caa",
+            "us-east-1f": "subnet-0cc340c5cf9346dcc",
+        },
+        "us-east-2": {
+            "us-east-2a": "subnet-05205c91d6a9f06e6",
+            "us-east-2b": "subnet-082be4d0d5e7e4d58",
+            "us-east-2c": "subnet-01eb0c6a5e15846db",
+        },
+    }
+
+    AWS_SECURITY_GROUPS = {
+        "us-west-1": {
+            "no-inbound": "sg-00c4014bc978171d5",
+            "docker-worker": "sg-0d2ff88f36a05b499",
+        },
+        "us-west-2": {
+            "no-inbound": "sg-0659c2937ecbe7254",
+            "docker-worker": "sg-0f8a656368c567425",
+        },
+        "us-east-1": {
+            "no-inbound": "sg-07f7d21a488e192c6",
+            "docker-worker": "sg-08fea1235cf66b102",
+        },
+        "us-east-2": {
+            "no-inbound": "sg-00a9d64b3595c5088",
+            "docker-worker": "sg-0388de36e2f30ced2  u",
+        },
+    }
+
+    # by default, deploy where there are images
+    if "regions" not in cfg:
+        regions = list(image_set.aws["amis"])
+    assert regions, "must give regions"
+
+    imageIds = image_set.aws["amis"]
+    assert imageIds, "must give imageIds"
 
     launchConfigs = []
     for region in regions:
         groupId = AWS_SECURITY_GROUPS[region][securityGroup]
         for az, subnetId in AWS_SUBNETS[region].items():
             for instanceType, capacityPerInstance in instanceTypes.items():
+                # Instance type m3.2xlarge isn't available in us-east-1a, so
+                # filter out that combination.
+                if az == "us-east-1a" and instanceType == "m3.2xlarge":
+                    continue
                 launchConfig = {
                     "capacityPerInstance": capacityPerInstance,
                     "region": region,
@@ -263,70 +277,56 @@ def base_aws_config(
     }
 
 
-def base_aws_generic_worker_config(**cfg):
-    """
-    Build a base for generic-worker in AWS
-    """
+@worker_implementation
+def generic_worker(image_set, wp, **cfg):
 
-    # by default, deploy where there are images
-    if "regions" not in cfg and "imageIds" in cfg:
-        cfg["regions"] = list(cfg["imageIds"])
+    # hashed = hashlib.sha256(json.dumps(configs, sort_keys=True).encode("utf8")).hexdigest()
+    # generic_worker_config["deploymentId"] = hashed[:16]
 
-    rv = base_aws_config(**cfg)
-
-    for launchConfig in rv["config"]["launchConfigs"]:
+    for launchConfig in wp["config"]["launchConfigs"]:
         launchConfig["workerConfig"] = {
             "genericWorker": {
                 "config": {
                     "deploymentId": "community-tc-config",
-                    "ed25519SigningKeyLocation": "C:\\generic-worker\\generic-worker-ed25519-signing-key.key",
-                    "livelogExecutable": "C:\\generic-worker\\livelog.exe",
                     "sentryProject": "generic-worker",
-                    "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
-                    "workerTypeMetadata": {},
                     "wstAudience": "communitytc",
                     "wstServerURL": "https://community-websocktunnel.services.mozilla.com",
                 },
             },
         }
+        launchConfig["workerConfig"] = merge(
+            launchConfig["workerConfig"], image_set.workerConfig
+        )
+        if "workerConfig" in cfg:
+            launchConfig["workerConfig"] = merge(
+                launchConfig["workerConfig"], cfg["workerConfig"]
+            )
+
+    return wp
+
+
+@worker_implementation
+def docker_worker(image_set, wp, **cfg):
+
+    for launchConfig in wp["config"]["launchConfigs"]:
+        launchConfig["workerConfig"] = merge(
+            launchConfig["workerConfig"], image_set.workerConfig
+        )
+        if "workerConfig" in cfg:
+            launchConfig["workerConfig"] = merge(
+                launchConfig["workerConfig"], cfg["workerConfig"]
+            )
 
     if cfg["secret_values"]:
-        # generic-worker crashes in the absence of a secret, so create an empty secret
-        rv["secret"] = {"config": {}, "files": []}
+        wp["secret"] = cfg["secret_values"].render(
+            {
+                "config": {
+                    "statelessHostname": {
+                        "secret": "$stateless-dns-secret",
+                        "domain": "taskcluster-worker.net",
+                    },
+                },
+            }
+        )
 
-    return rv
-
-
-@worker_pool_type
-def standard_aws_generic_worker_win2012r2(**cfg):
-    """
-    Build a standard Win2012R2 worker instance in AWS
-    """
-    rv = base_aws_generic_worker_config(
-        imageIds=DEFAULT_AWS_WIN2012_GENERIC_WORKER_IMAGES,
-        instanceTypes={"m3.2xlarge": 1},
-        **cfg,
-    )
-
-    # instance type m3.2xlarge isn't available in this us-east-1a, so we filter
-    # out that zone
-    rv["config"]["launchConfigs"] = [
-        lc
-        for lc in rv["config"]["launchConfigs"]
-        if lc["launchConfig"]["Placement"]["AvailabilityZone"] != "us-east-1a"
-    ]
-
-    return rv
-
-
-@worker_pool_type
-def aws_generic_worker_deepspeech_win(imageIds={}, **cfg):
-    """
-    Build a deepspeech windows worker instance in AWS, with images
-    specified in the project config
-    """
-    rv = base_aws_generic_worker_config(
-        imageIds=imageIds, instanceTypes={"m5d.2xlarge": 1}, **cfg
-    )
-
-    return rv
+    return wp


### PR DESCRIPTION
The aim of this second PR is to restructure the organisation of the code and configs a little to enable additional metadata to be associated to machine images, and provide a slightly more generic means for worker config to be associated to worker pools.