### PR TITLE
Support worker-implementation specific scopes, shrink generic-worker configs, and configure deploymentId

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -62,8 +62,6 @@ generic-worker-win2012r2:
     genericWorker:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
-        livelogExecutable: C:\generic-worker\livelog.exe
-        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
@@ -82,8 +80,6 @@ generic-worker-win2012r2-staging:
     genericWorker:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
-        livelogExecutable: C:\generic-worker\livelog.exe
-        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
@@ -100,9 +96,6 @@ generic-worker-ubuntu-18-04:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        livelogExecutable: /usr/local/bin/livelog
-        taskclusterProxyExecutable: /usr/local/bin/taskcluster-proxy
-        tasksDir: /home
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
@@ -119,9 +112,6 @@ generic-worker-ubuntu-18-04-staging:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        livelogExecutable: /usr/local/bin/livelog
-        taskclusterProxyExecutable: /usr/local/bin/taskcluster-proxy
-        tasksDir: /home
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
@@ -138,8 +128,6 @@ deepspeech-win2012r2:
     genericWorker:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
-        livelogExecutable: C:\generic-worker\livelog.exe
-        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         workerTypeMetadata:
           machine-setup:
             maintainer: alissy@mozilla.com

--- a/generate/projects.py
+++ b/generate/projects.py
@@ -115,14 +115,16 @@ async def update_resources(resources, secret_values):
                 worker_pool_id = "proj-{}/{}".format(project.name, name)
                 worker_pool["description"] = "Workers for " + project.name
                 image_set = imageSets[worker_pool["imageset"]]
-                worker_pool, secret = build_worker_pool(
+                worker_pool, secret, role = build_worker_pool(
                     worker_pool_id, worker_pool, secret_values, image_set
                 )
                 if project.externallyManaged.manage_individual_resources():
                     resources.manage("WorkerPool={}".format(worker_pool_id))
+                    resources.manage("Role=" + re.escape(role.roleId))
                     if secret:
                         resources.manage("Secret=worker-pool:{}".format(worker_pool_id))
                 resources.add(worker_pool)
+                resources.add(role)
                 if secret:
                     resources.add(secret)
         if project.clients:

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -70,19 +70,14 @@ def build_worker_pool(workerPoolId, cfg, secret_values, image_set):
         )
 
         for launchConfig in wp["config"]["launchConfigs"]:
-            launchConfig["workerConfig"] = (
-                image_set.workerConfig
-                if "workerConfig" not in launchConfig
-                else merge(
-                    image_set.workerConfig,  # takes precedence
-                    launchConfig["workerConfig"],
-                )
+            launchConfig["workerConfig"] = merge(
+                image_set.workerConfig,  # takes precedence
+                launchConfig.get("workerConfig", {}),
             )
-            if "workerConfig" in cfg:
-                launchConfig["workerConfig"] = merge(
-                    cfg["workerConfig"],  # takes precedence
-                    launchConfig["workerConfig"],
-                )
+            launchConfig["workerConfig"] = merge(
+                cfg.get("workerConfig", {}),  # takes precedence
+                launchConfig["workerConfig"],
+            )
 
         wp = WORKER_IMPLEMENTATION_FUNCS[
             image_set.workerImplementation.replace("-", "_")


### PR DESCRIPTION
This adds support for enabling `generic-worker` or `docker-worker` specific scopes, and cloud-specific scopes. This use case for this was wanting to give `auth:sentry:generic-worker` to all generic-worker workers.