### PR TITLE
Add client for manually configured proj-taskcluster/gw-ci-windows10-amd64

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -276,10 +276,10 @@ taskcluster:
       scopes:
         - assume:worker-pool:proj-taskcluster/gw-ci-raspbian-stretch
         - assume:worker-id:proj-taskcluster/*
-    # Client for workerpool proj-taskcluster/gw-ci-windows10-amd64. This is
-    # currently a manually configured worker pool with a single worker, running
-    # in Azure. When we have an azure provider, we can terminate this worker,
-    # delete this client, and use worker manager provisioned instances instead.
+    # Client for proj-taskcluster/gw-ci-windows10-amd64. This client is
+    # currently used by a single manually configured worker, running in Azure.
+    # When we have an azure provider, we can terminate this worker, delete this
+    # client, and use worker manager provisioned instances instead.
     generic-worker/ci-windows10-amd64:
       scopes:
         - assume:worker-pool:proj-taskcluster/gw-ci-windows10-amd64

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -276,6 +276,14 @@ taskcluster:
       scopes:
         - assume:worker-pool:proj-taskcluster/gw-ci-raspbian-stretch
         - assume:worker-id:proj-taskcluster/*
+    # Client for workerpool proj-taskcluster/gw-ci-windows10-amd64. This is
+    # currently a manually configured worker pool with a single worker, running
+    # in Azure. When we have an azure provider, we can terminate this worker,
+    # delete this client, and use worker manager provisioned instances instead.
+    generic-worker/ci-windows10-amd64:
+      scopes:
+        - assume:worker-pool:proj-taskcluster/gw-ci-windows10-amd64
+        - assume:worker-id:proj-taskcluster/*
     # Client for workerpool proj-taskcluster/gw-ci-windows10-arm
     generic-worker/ci-windows10-arm:
       scopes:


### PR DESCRIPTION
This is a stop gap for generic-worker CI until we have an azure provider.