### PR TITLE
[Bug 1601810] Allow relman to notify

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -137,6 +137,10 @@
     - queue:schedule-task:-/*
     - queue:rerun-task:-/*
 
+    - notify:email:*
+    - notify:irc-channel:*
+    - notify:irc-user:*
+
     # permission to run interactive tsaks
     - queue:get-artifact:private/docker-worker/*
   to:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -640,6 +640,7 @@ relman:
     bugbug/code-review-testing:
       scopes:
         - hooks:trigger-hook:project-relman/bugbug-*
+        - notify:email:*
   workerPools:
     ci:
       owner: mcastelluccio@mozilla.com

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -632,6 +632,14 @@ relman:
     - github.com/mozilla/rust-code-analysis:*
     - github.com/mozilla/dump_syms:*
     - github.com/mozilla/libmozevent:*
+  clients:
+    bugbug/code-review-production:
+      scopes:
+        - hooks:trigger-hook:project-relman/bugbug-*
+        - notify:email:*
+    bugbug/code-review-testing:
+      scopes:
+        - hooks:trigger-hook:project-relman/bugbug-*
   workerPools:
     ci:
       owner: mcastelluccio@mozilla.com


### PR DESCRIPTION
These clients already exist so I just imported them into this config. Let me know if you'd rather manually configure them, @marco-c (I think maybe client support didn't exist here when we first set up relman).

This also gives all of the "admin types" broad notify permissions.