### PR TITLE
Add scopes for code-review integration tests hooks.

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -773,10 +773,24 @@ relman:
     # code-review
     - grant: docker-worker:capability:privileged
       to: repo:github.com/mozilla/code-review:*
-    - grant: secrets:get:project/relman/code-review/deploy-production
+    - grant:
+        - secrets:get:project/relman/code-review/deploy-production
+        - assume:hook-id:project-relman/code-review-integration-production
+        - hooks:modify-hook:project-relman/code-review-integration-production
       to: repo:github.com/mozilla/code-review:branch:production
-    - grant: secrets:get:project/relman/code-review/deploy-testing
+    - grant:
+        - secrets:get:project/relman/code-review/deploy-testing
+        - assume:hook-id:project-relman/code-review-integration-testing
+        - hooks:modify-hook:project-relman/code-review-integration-testing
       to: repo:github.com/mozilla/code-review:branch:testing
+    - grant:
+        - notify:email:*
+        - secrets:get:project/relman/code-review/integration-testing
+      to: hook-id:project-relman/code-review-integration-testing
+    - grant:
+        - notify:email:*
+        - secrets:get:project/relman/code-review/integration-production
+      to: hook-id:project-relman/code-review-integration-production
 
     # dump_syms
     - grant: secrets:get:project/relman/dump_syms/deploy


### PR DESCRIPTION
I'm adding [integration tests to the code-review project](https://github.com/mozilla/code-review/issues/297) and need a few more scopes:

- the github worker need to be able to create & update a hook on the community instance
- the hook need to send emails & read a secret

Thanks !