### PR TITLE
Roll out generic-worker 16.5.6 to Ubuntu/Windows staging image sets

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -71,11 +71,11 @@ generic-worker-win2012r2-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-00614f567630f5112
-      us-west-1: ami-05066089eb30e5267
-      us-west-2: ami-064bb0815b490b5fa
+      us-east-1: ami-0c0a237f391623444
+      us-west-1: ami-05fe270f0f5e45407
+      us-west-2: ami-04560dd7e051c626a
   gcp:
-    image: projects/pmoore-dev/global/images/generic-worker-win2012r2-staging-w5scg38b0gagvkv6yj1m
+    image: projects/pmoore-dev/global/images/generic-worker-win2012r2-staging-6768u5givhm8ubt6r6of
   workerConfig:
     genericWorker:
       config:
@@ -105,9 +105,9 @@ generic-worker-ubuntu-18-04-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-029a1539ae3ce69b0
-      us-west-1: ami-047fd83611b397644
-      us-west-2: ami-056c7a4b568d09255
+      us-east-1: ami-0ff242b08b0d28f6c
+      us-west-1: ami-0982838b21ddfc280
+      us-west-2: ami-07a761e8aa72c8d7b
   workerConfig:
     genericWorker:
       config:

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -6,7 +6,7 @@ exec &> /var/log/bootstrap.log
 # Versions ###########################
 LIVELOG_VERSION='v1.1.0'
 TASKCLUSTER_PROXY_VERSION='v5.1.0'
-GENERIC_WORKER_BRANCH='bug1593483-part2'
+GENERIC_WORKER_REF='v16.5.6'
 ######################################
 
 function retry {
@@ -47,7 +47,7 @@ sleep 5
 systemctl status docker | grep "Started Docker Application Container Engine"
 usermod -aG docker ubuntu
 
-# build generic-worker from ${GENERIC_WORKER_BRANCH} branch
+# build generic-worker from ${GENERIC_WORKER_REF} commit / branch / tag etc
 retry curl -L 'https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz' > go.tar.gz
 tar xvfz go.tar.gz -C /usr/local
 export HOME=/root
@@ -56,7 +56,7 @@ export GOROOT=/usr/local/go
 export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 go get -d github.com/taskcluster/generic-worker
 cd "${GOPATH}/src/github.com/taskcluster/generic-worker"
-git checkout "${GENERIC_WORKER_BRANCH}"
+git checkout "${GENERIC_WORKER_REF}"
 CGO_ENABLED=0 go install -tags multiuser -ldflags "-X main.revision=$(git rev-parse HEAD)" github.com/taskcluster/generic-worker
 mv "${GOPATH}/bin/generic-worker" /usr/local/bin/
 

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -82,7 +82,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.5.5/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.5.6/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")


### PR DESCRIPTION
Rolling out [generic-worker 16.5.6](https://github.com/taskcluster/generic-worker/releases/v16.5.6) to staging image sets.