### PR TITLE
Change fuzzing project admin.

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -530,7 +530,7 @@ misc:
 
 fuzzing:
   adminRoles:
-    - github-org-admin:MozillaSecurity
+    - github-team:MozillaSecurity/tc-admin
   repos:
     - github.com/MozillaSecurity/*
   secrets:


### PR DESCRIPTION
Change admin to a manageable team instead of the Github org owner so we can separate these privileges.