### PR TITLE
Allow triggering the fuzzing decision task manually

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -604,6 +604,8 @@ fuzzing:
         - repo:github.com/MozillaSecurity/*
     - grant:
         - secrets:get:project/fuzzing/decision
+        - queue:scheduler-id:-
+        - queue:create-task:highest:proj-fuzzing/decision
       to: hook-id:project-fuzzing/decision
 
 git-cinnabar:


### PR DESCRIPTION
```
The role hook-id:project-fuzzing/decision does not have sufficient scopes to create the task:

Client ID static/taskcluster/hooks does not have sufficient scopes and is missing the following scopes:

{
  "AnyOf": [
    {
      "AllOf": [
        "queue:scheduler-id:-",
        {
          "AnyOf": [
            "queue:create-task:highest:proj-fuzzing/decision",
            "queue:create-task:very-high:proj-fuzzing/decision",
            "queue:create-task:high:proj-fuzzing/decision",
            "queue:create-task:medium:proj-fuzzing/decision",
            "queue:create-task:low:proj-fuzzing/decision",
            "queue:create-task:very-low:proj-fuzzing/decision",
            "queue:create-task:lowest:proj-fuzzing/decision"
          ]
        }
      ]
    },
    {
      "AnyOf": [
        "queue:create-task:proj-fuzzing/decision",
        {
          "AllOf": [
            "queue:define-task:proj-fuzzing/decision",
            "queue:task-group-id:-/W-NdF07pSEascutMuX5hvw",
            "queue:schedule-task:-/W-NdF07pSEascutMuX5hvw/W-NdF07pSEascutMuX5hvw"
          ]
        }
      ]
    }
  ]
}
```