### PR TITLE
Bug 1608828 - grant generic-worker CI rights to monorepo

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -284,7 +284,9 @@ taskcluster:
         - queue:create-task:highest:proj-taskcluster/gw-ci-*
         - generic-worker:cache:generic-worker-checkout
         - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
-      to: repo:github.com/taskcluster/generic-worker:*
+      to:
+        - repo:github.com/taskcluster/generic-worker:*
+        - repo:github.com/taskcluster/taskcluster:*
 
   clients:
     smoketests:


### PR DESCRIPTION
See [bug 1608828](https://bugzil.la/1608828) for context. Thanks!