### PR TITLE
Grant generic docker-worker:cache:bugbug-* to project:relman:bugbug/build

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -832,8 +832,7 @@ relman:
 
     # bugbug
     - grant:
-        - docker-worker:cache:bugbug-build
-        - docker-worker:cache:bugbug-mercurial-repository
+        - docker-worker:cache:bugbug-*
         - docker-worker:capability:privileged
         - secrets:get:project/relman/bugbug/integration
       to: project:relman:bugbug/build


### PR DESCRIPTION
This way we can create new caches easily.