### PR TITLE
Add a new worker type specifically for bugbug regressor-finder task

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -776,6 +776,14 @@ relman:
       minCapacity: 1
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-8"
+    compute-large-regressor-finder:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 1
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-8"
     compute-super-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This is exactly like the worker type above, but it is separate as I need a cache specifically for a specific task.