### PR TITLE
Bug 1588083 - use scheduler-id:smoketest for smoketests

### DIFF
--- a/config/projects.yml
+++ b/config/projects.yml
@@ -250,7 +250,7 @@ taskcluster:
         - queue:create-task:highest:built-in/fail
         - queue:create-task:highest:built-in/succeed
         - queue:route:index.project.taskcluster.smoketest.*
-        - queue:scheduler-id:-
+        - queue:scheduler-id:smoketest
         - secrets:get:project/taskcluster/smoketest/*
         - secrets:set:project/taskcluster/smoketest/*
       to: project:taskcluster:smoketests


### PR DESCRIPTION
Bugzilla Bug: [1588083](https://bugzilla.mozilla.org/show_bug.cgi?id=1588083)

Small change per @tomprince's request in https://phabricator.services.mozilla.com/D58272#inline-366030