### PR TITLE
Install gcc on staging generic-worker worker types

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -74,11 +74,12 @@ generic-worker-win2012r2-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-0162f92052875bf7e
-      us-west-1: ami-0f6b26130f2f9ce2c
-      us-west-2: ami-0dfd8045878e6cd08
-  gcp:
-    image: projects/community-tc-workers/global/images/generic-worker-win2012r2-staging-hasr18iepqtggvlswlku
+      us-east-1: ami-0f892d6ff7cdc52e7
+      us-west-1: ami-0cf711badfa2f50fc
+      us-west-2: ami-02ed2a69fdfdef0bc
+# Currently not deployed in gcp...
+# gcp:
+#   image: projects/community-tc-workers/global/images/generic-worker-win2012r2-staging-hasr18iepqtggvlswlku
   workerConfig:
     genericWorker:
       config:

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -134,9 +134,9 @@ generic-worker-ubuntu-18-04-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-06ce1a5f3039ac646
-      us-west-1: ami-0bd5b1b63c47a7b65
-      us-west-2: ami-0a396cff215e28640
+      us-east-1: ami-0e785d8c0d91ba485
+      us-west-1: ami-03b04649c13e7ec0c
+      us-west-2: ami-021550227b98d65e7
   workerConfig:
     genericWorker:
       config:

--- a/config/projects.yml
+++ b/config/projects.yml
@@ -152,7 +152,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2-staging
-      cloud: gcp
+      cloud: aws
       maxCapacity: 10
       workerConfig:
         genericWorker:

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -36,7 +36,7 @@ start_time="$(date '+%s')"
 
 retry apt update
 DEBIAN_FRONTEND=noninteractive apt upgrade -yq
-retry apt install -y apt-transport-https ca-certificates curl software-properties-common git tar python3-venv python-virtualenv
+retry apt install -y apt-transport-https ca-certificates curl software-properties-common git tar python3-venv python-virtualenv build-essential
 
 # install docker
 retry curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -207,7 +207,7 @@ $client.DownloadFile("https://www.cygwin.com/setup-x86_64.exe", "C:\cygwin-setup
 
 # install cygwin
 # complete package list: https://cygwin.com/packages/package_list.html
-Start-Process "C:\cygwin-setup-x86_64.exe" -ArgumentList "--quiet-mode --wait --root C:\cygwin --site http://cygwin.mirror.constant.com --packages openssh,vim,curl,tar,wget,zip,unzip,diffutils,bzr" -Wait -NoNewWindow -PassThru -RedirectStandardOutput "C:\cygwin_install.log" -RedirectStandardError "C:\cygwin_install.err"
+Start-Process "C:\cygwin-setup-x86_64.exe" -ArgumentList "--quiet-mode --wait --root C:\cygwin --site http://cygwin.mirror.constant.com --packages openssh,vim,curl,tar,wget,zip,unzip,diffutils,bzr,gcc-g++" -Wait -NoNewWindow -PassThru -RedirectStandardOutput "C:\cygwin_install.log" -RedirectStandardError "C:\cygwin_install.err"
 
 # open up firewall for ssh daemon
 New-NetFirewallRule -DisplayName "Allow SSH inbound" -Direction Inbound -LocalPort 22 -Protocol TCP -Action Allow


### PR DESCRIPTION
This PR installs gcc on staging windows/ubuntu generic-worker worker types.

This is useful for overcoming [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1523934#c2) where gcc seems to be needed after upgrading to work with CGO. I'm not sure how it worked before without gcc.

Note, I commented out some parts of the staging ubuntu image set that installed generic-worker from source, rather than deleting them, since it is highly likely that this will be useful in future (typically we build from source on staging to get a development version before deciding whether to release or not).

Note, we can squash the commits if you are happy with the change.

Also note I've deployed the changes to the staging worker types already, so this PR just ensures the current source versions match what is currently deployed.