### PR TITLE
Allow github repo MozillaSecurity/fuzzing-tc to publish in index

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -50,6 +50,7 @@ fuzzing:
         - repo:github.com/MozillaSecurity/*
     - grant:
         - docker-worker:capability:privileged
+        - queue:route:index.project.fuzzing.config.*
       to:
         - repo:github.com/MozillaSecurity/fuzzing-tc:*
     - grant:


### PR DESCRIPTION
Blocks https://github.com/MozillaSecurity/fuzzing-tc/pull/18