### PR TITLE
Increase idle timeout of proj-taskcluster/windows2012r2-amd64-ci worker pool to 1h

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -28,6 +28,13 @@ taskcluster:
       imageset: generic-worker-win2012r2
       cloud: gcp
       maxCapacity: 10
+      workerConfig:
+        genericWorker:
+          config:
+            # Default timeout is 90s, but pool keeps emptying during working
+            # hours. Useful to keep alive to reduce pending time for the
+            # generic-worker decision task in monorepo.
+            idleTimeoutSecs: 3600
 
     release:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
This will help reduce pending times during working hours while waiting for taskcluster monorepo generic-worker decision task to run.