### PR TITLE
Increase idle timeout for generic-worker CI tasks

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -28,13 +28,6 @@ taskcluster:
       imageset: generic-worker-win2012r2
       cloud: gcp
       maxCapacity: 10
-      workerConfig:
-        genericWorker:
-          config:
-            # Default timeout is 90s, but pool keeps emptying during working
-            # hours. Useful to keep alive to reduce pending time for the
-            # generic-worker decision task in monorepo.
-            idleTimeoutSecs: 3600
 
     release:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -59,6 +52,9 @@ taskcluster:
         genericWorker:
           config:
             runTasksAsCurrentUser: true
+            # Default timeout is 90s, but pool keeps emptying during working
+            # hours. Useful to keep alive to reduce pending time for CI tasks.
+            idleTimeoutSecs: 3600
 
     gw-ci-ubuntu-18-04-staging:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -81,6 +77,9 @@ taskcluster:
         genericWorker:
           config:
             runTasksAsCurrentUser: true
+            # Default timeout is 90s, but pool keeps emptying during working
+            # hours. Useful to keep alive to reduce pending time for CI tasks.
+            idleTimeoutSecs: 3600
 
     gw-ci-windows2012r2-amd64-staging:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
Originally attempted in #199 I realised afterwards I updated the wrong worker pool!

This time I was more careful. ;-)

Also updating the Windows Server 2012 R2 CI worker pool for similar gain.

Thanks!