### PR TITLE
Build fuzzing worker pools with Taskcluster CI/CD

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -24,13 +24,6 @@ fuzzing:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
-    decision:
-      owner: fuzzing+taskcluster@mozilla.com
-      emailOnError: false
-      imageset: docker-worker
-      cloud: gcp
-      minCapacity: 0
-      maxCapacity: 10
     generic-worker-ubuntu-18-04-podman:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false
@@ -55,6 +48,5 @@ fuzzing:
         - repo:github.com/MozillaSecurity/fuzzing-tc:*
     - grant:
         - secrets:get:project/fuzzing/decision
-        - queue:create-task:highest:proj-fuzzing/decision
       to:
         - repo:github.com/MozillaSecurity/fuzzing-tc-config:*

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -47,3 +47,10 @@ fuzzing:
         - secrets:get:project/fuzzing/decision
       to:
         - repo:github.com/MozillaSecurity/fuzzing-tc-config:*
+
+    # fuzzing-tc-config code on master can run tc-admin apply to manage worker pools
+    - grant:
+       - worker-manager:manage-worker-pool:proj-fuzzing/*
+       - worker-manager:provider:community-tc-workers-*
+      to:
+       - repo:github.com/MozillaSecurity/fuzzing-tc-config:branch:master

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -21,9 +21,6 @@ fuzzing:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 10
-      workerConfig:
-        dockerConfig:
-          allowPrivileged: true
     generic-worker-ubuntu-18-04-podman:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This PR does several things:
1. Remove the useless `decision` worker pool, we only need `ci` to be static
2. Remove the privileged mode from `ci` worker pool, as the [docker image is now built with dind](https://github.com/MozillaSecurity/fuzzing-tc/issues/8)
3. As `tc-admin diff` now runs on every [MozillaSecurity/fuzzing-tc-config](https://github.com/MozillaSecurity/fuzzing-tc-config) pull request, we need to run `tc-admin apply` on every merge on master. So worker-manager scopes are requested for that branch.