### PR TITLE
Move GCP constants in dedicated YAML file

### DIFF
--- a/config/gcp.yml
+++ b/config/gcp.yml
@@ -1,0 +1,21 @@
+---
+# This file describes GCP constants used to build worker pools
+# It supports one top level dictionaries:
+#
+# # List all the available regions and their associated availability zone
+# regions:
+#   <gcp-region-name>:
+#     zones:
+#       - <gcp-availability-zone>
+#
+# Please do not move or edit the structure of that file as
+# it's being actively used by the fuzzing team decision task
+# to manage worker pools
+# If you remove a region, please reach out to fuzzing+taskcluster@mozilla.com
+
+regions:
+  us-east1:
+    zones: ["b", "c", "d"]
+
+  us-east4:
+    zones: ["a", "b", "c"]

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -231,15 +231,17 @@ def gcp(
 
     GOOGLE_PROVIDER = "community-tc-workers-google"
 
-    GOOGLE_REGIONS_ZONES = {
-        "us-east1": ["b", "c", "d"],
-        "us-east4": ["a", "b", "c"],
-    }
+    # Use local yaml file for GCP network constants
+    # These constants are set in a separate file to be used by external services
+    # like the fuzzing team decision tasks
+    _config_path = os.path.join(os.path.dirname(__file__), "../config/gcp.yml")
+    assert os.path.exists(_config_path), "Missing gcp config in {}".format(_config_path)
+    gcp_config = yaml.safe_load(open(_config_path))
 
     GOOGLE_ZONES_REGIONS = [
         ("{}-{}".format(region, zone), region)
-        for region, zones in sorted(GOOGLE_REGIONS_ZONES.items())
-        for zone in zones
+        for region, zones in sorted(gcp_config["regions"].items())
+        for zone in zones["zones"]
     ]
 
     assert maxCapacity, "must give a maxCapacity"


### PR DESCRIPTION
This is the same PR as #167 but for GCP.
It's needed by the fuzzing decision task - to be able to build workerpools on GCP