### PR TITLE
remove unnecessary, invalid scope

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -211,7 +211,6 @@ taskcluster:
         - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
         - queue:get-artifact:SampleArtifacts/b/c/d.jpg
         - queue:resolve-task
-        - assume:worker-id:test-worker-group/*"
       to: project:taskcluster:generic-worker-tester
 
     - grant:


### PR DESCRIPTION
This scope ends with a `"`" character, so the `*` beforehand does not
match anything.  Thus this role would only work for a workerId of `*"`,
which we don't have.  So, the scope is unnecessary.