### PR TITLE
Set fuzzing project as externally managed.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -1,6 +1,7 @@
 fuzzing:
   adminRoles:
     - github-team:MozillaSecurity/tc-admin
+  externallyManaged: true # Fuzzing hooks are deployed through another repo
   repos:
     - github.com/MozillaSecurity/*
   secrets:


### PR DESCRIPTION
As hooks & worker pools are managed through https://github.com/MozillaSecurity/fuzzing-tc