### PR TITLE
Move taskcluster windows workers from gcp to aws

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -26,7 +26,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2
-      cloud: gcp
+      cloud: aws
       maxCapacity: 10
 
     release:
@@ -71,7 +71,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2
-      cloud: gcp
+      cloud: aws
       maxCapacity: 10
       workerConfig:
         genericWorker:
@@ -85,7 +85,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2012r2-staging
-      cloud: gcp
+      cloud: aws
       maxCapacity: 10
       workerConfig:
         genericWorker:


### PR DESCRIPTION
We seem to have some problems in gcp at the moment, and I think since long term we're not too concerned about having windows workers in gcp, let's just move to aws and save ourselves some troubleshooting.

See https://community-tc.services.mozilla.com/provisioners/proj-taskcluster/worker-types/windows2012r2-amd64-ci