### PR TITLE
Grant to Servo admins scope to notify their Matrix room

### DIFF
--- a/config/projects/servo.yml
+++ b/config/projects/servo.yml
@@ -26,6 +26,8 @@ servo:
     - grant:
         # notification
         - queue:route:notify.irc-channel.#servo.*
+        - queue:route:notify.matrix-room.#servo:mozilla.org.*
+        - queue:route:notify.matrix-room.!crXxRMedJXFPxKffWI:mozilla.org.*
 
         # treeherder submission
         - queue:route:tc-treeherder-staging.v2._/servo-*


### PR DESCRIPTION
I don’t know if an alias like `#servo:mozilla.org` works of if the full ID `!crXxRMedJXFPxKffWI:mozilla.org` is required so this adds both so I can try them.

Does the dot in `mozilla.org` need to be escaped?

CC https://bugzilla.mozilla.org/show_bug.cgi?id=1522154