### PR TITLE
Add denyist administration for TC team

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -100,6 +100,11 @@ taskcluster:
 
   grants:
     - grant:
+        - notify:manage-denylist
+      to:
+        - project-admin:taskcluster
+
+    - grant:
         - queue:create-task:highest:proj-taskcluster/ci
         - queue:create-task:highest:proj-taskcluster/windows2012r2-amd64-ci
         # The account and secret for the Azure testing storage account.


### PR DESCRIPTION
I noticed this was missing when I went to test denylisting matrix notifications.