### PR TITLE
Grant non-deprecated scopes to g-w CI

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -221,7 +221,7 @@ taskcluster:
         - queue:cancel-task:test-scheduler/*
         - assume:worker-pool:test-provisioner/*
         - queue:create-artifact:public/*
-        - queue:create-task:test-provisioner/*
+        - queue:create-task:highest:test-provisioner/*
         - queue:get-artifact:SampleArtifacts/_/X.txt
         - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
         - queue:get-artifact:SampleArtifacts/b/c/d.jpg


### PR DESCRIPTION
Fixes failures like [this](https://community-tc.services.mozilla.com/tasks/XpiGh08eTAC-geB1NMzTEw/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FXpiGh08eTAC-geB1NMzTEw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log)