### PR TITLE
Upgrade all image sets to generic-worker v28.0.0

### DIFF
--- a/imagesets/deepspeech-win2012r2-gpu/bootstrap.ps1
+++ b/imagesets/deepspeech-win2012r2-gpu/bootstrap.ps1
@@ -110,7 +110,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 
 # install generic-worker, using the batch script suggested in https://github.com/taskcluster/taskcluster-worker-runner/blob/master/docs/windows-services.md
 Set-Content -Path c:\generic-worker\install.bat @"

--- a/imagesets/deepspeech-win2012r2/bootstrap.ps1
+++ b/imagesets/deepspeech-win2012r2/bootstrap.ps1
@@ -110,7 +110,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 
 # install generic-worker, using the batch script suggested in https://github.com/taskcluster/taskcluster-worker-runner/blob/master/docs/windows-services.md
 Set-Content -Path c:\generic-worker\install.bat @"

--- a/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
+++ b/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
@@ -34,7 +34,7 @@ Set-Acl "C:\builds" $acl
 $client.DownloadFile("https://raw.githubusercontent.com/mozilla/release-services/master/src/tooltool/client/tooltool.py", "C:\builds\tooltool.py")
 Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm.cc/release/nssm-2.24.zip"
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 Set-Content -Path c:\generic-worker\install.bat @"
 set nssm=C:\nssm-2.24\win64\nssm.exe
 %nssm% install "Generic Worker" c:\generic-worker\generic-worker.exe

--- a/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
@@ -5,7 +5,7 @@ exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
 WORKER_RUNNER_VERSION='v1.0.1'
-GENERIC_WORKER_VERSION='v16.5.6'
+GENERIC_WORKER_VERSION='v28.0.0'
 LIVELOG_VERSION='v1.1.0'
 TASKCLUSTER_PROXY_VERSION='v5.1.0'
 ######################################
@@ -45,7 +45,7 @@ apt-get update -qq
 apt-get -qq -y install podman
 
 cd /usr/local/bin
-retry curl -L "https://github.com/taskcluster/generic-worker/releases/download/${GENERIC_WORKER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
+retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${GENERIC_WORKER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
 retry curl -L "https://github.com/taskcluster/taskcluster-worker-runner/releases/download/${WORKER_RUNNER_VERSION}/start-worker-linux-amd64" > start-worker
 retry curl -L "https://github.com/taskcluster/livelog/releases/download/${LIVELOG_VERSION}/livelog-linux-amd64" > livelog
 retry curl -L "https://github.com/taskcluster/taskcluster-proxy/releases/download/${TASKCLUSTER_PROXY_VERSION}/taskcluster-proxy-linux-amd64" > taskcluster-proxy

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -7,7 +7,7 @@ exec &> /var/log/bootstrap.log
 WORKER_RUNNER_VERSION='v1.0.1'
 LIVELOG_VERSION='v1.1.0'
 TASKCLUSTER_PROXY_VERSION='v5.1.0'
-GENERIC_WORKER_REF='v16.5.6'
+GENERIC_WORKER_REF='v28.0.0'
 ######################################
 
 function retry {
@@ -49,16 +49,17 @@ systemctl status docker | grep "Started Docker Application Container Engine"
 usermod -aG docker ubuntu
 
 # build generic-worker from ${GENERIC_WORKER_REF} commit / branch / tag etc
-retry curl -L 'https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz' > go.tar.gz
+retry curl -L 'https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz' > go.tar.gz
 tar xvfz go.tar.gz -C /usr/local
 export HOME=/root
 export GOPATH=~/go
 export GOROOT=/usr/local/go
 export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
-go get -d github.com/taskcluster/generic-worker
-cd "${GOPATH}/src/github.com/taskcluster/generic-worker"
+go get -d github.com/taskcluster/taskcluster
+cd "${GOPATH}/src/github.com/taskcluster/taskcluster"
 git checkout "${GENERIC_WORKER_REF}"
-CGO_ENABLED=0 go install -tags multiuser -ldflags "-X main.revision=$(git rev-parse HEAD)" github.com/taskcluster/generic-worker
+cd workers/generic-worker
+CGO_ENABLED=0 go install -tags multiuser -ldflags "-X main.revision=$(git rev-parse HEAD)"
 mv "${GOPATH}/bin/generic-worker" /usr/local/bin/
 
 # install livelog and taskcluster-proxy

--- a/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
@@ -5,7 +5,7 @@ exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
 WORKER_RUNNER_VERSION='v1.0.1'
-GENERIC_WORKER_VERSION='v16.5.6'
+GENERIC_WORKER_VERSION='v28.0.0'
 LIVELOG_VERSION='v1.1.0'
 TASKCLUSTER_PROXY_VERSION='v5.1.0'
 ######################################
@@ -49,7 +49,7 @@ systemctl status docker | grep "Started Docker Application Container Engine"
 usermod -aG docker ubuntu
 
 cd /usr/local/bin
-retry curl -L "https://github.com/taskcluster/generic-worker/releases/download/${GENERIC_WORKER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
+retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${GENERIC_WORKER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
 retry curl -L "https://github.com/taskcluster/taskcluster-worker-runner/releases/download/${WORKER_RUNNER_VERSION}/start-worker-linux-amd64" > start-worker
 retry curl -L "https://github.com/taskcluster/livelog/releases/download/${LIVELOG_VERSION}/livelog-linux-amd64" > livelog
 retry curl -L "https://github.com/taskcluster/taskcluster-proxy/releases/download/${TASKCLUSTER_PROXY_VERSION}/taskcluster-proxy-linux-amd64" > taskcluster-proxy

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -77,7 +77,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 
 # install generic-worker, using the batch script suggested in https://github.com/taskcluster/taskcluster-worker-runner/blob/master/docs/windows-services.md
 Set-Content -Path c:\generic-worker\install.bat @"

--- a/imagesets/generic-worker-win2012r2/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2/bootstrap.ps1
@@ -77,7 +77,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 
 # install generic-worker, using the batch script suggested in https://github.com/taskcluster/taskcluster-worker-runner/blob/master/docs/windows-services.md
 Set-Content -Path c:\generic-worker\install.bat @"

--- a/imagesets/generic-worker-win2016/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016/bootstrap.ps1
@@ -77,7 +77,7 @@ Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" -Url "http://www.nssm
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v16.6.0/generic-worker-multiuser-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/taskcluster/releases/download/v28.0.0/generic-worker-multiuser-windows-amd64", "C:\generic-worker\generic-worker.exe")
 
 # install generic-worker, using the batch script suggested in https://github.com/taskcluster/taskcluster-worker-runner/blob/master/docs/windows-services.md
 Set-Content -Path c:\generic-worker\install.bat @"


### PR DESCRIPTION
Eventually, these updates should be automatic, but for now, I thought good to update manually.

Note, I'll create a separate PR (or Issue) for downloading the new monorepo taskcluster-worker binaries. At the moment, the `bootstrap.ps1` and `bootstrap.sh` scripts still download taskcluster-worker-runner release binaries from the old repo.