### PR TITLE
Use the deepspeech Windows imageset for win2012r2 relman workers

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -67,7 +67,7 @@ relman:
     win2012r2:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
-      imageset: generic-worker-win2012r2
+      imageset: deepspeech-win2012r2
       cloud: aws
       maxCapacity: 10
   secrets:


### PR DESCRIPTION
I'd need a Windows image containing Visual Studio Build Tools.
I have three options:
1) Set up a new imageset specific for my task;
2) Use the deepspeech image;
3) Add Visual Studio Build Tools to the generic image.

1 seems overkill, given that (at least for now) it will be used by a single task in a single project.
2 is super-easy, but might be unstable (there's no guarantee they will keep what I need).
3 would be easy, but would increase the size of the generic image and might have side effects in other projects using the same image (although I think there is low chance there will be side effects).

I think between the three options I prefer the second, because the task is not sensitive and it's OK if it's broken for a few days.