### PR TITLE
Update community image to drop invalid packets for wpt#21529

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -48,10 +48,16 @@ generic-worker:
   workerImplementation: generic-worker
   # (this is intended for use with static workers)
 
+# If you are updating this after April 27, 2020 please remove the iptables-fix version of this and port everyhing back to normal docker-worker
 docker-worker:
   workerImplementation: docker-worker
   gcp:
     image: projects/taskcluster-imaging/global/images/docker-worker-gcp-googlecompute-2020-03-12t12-33-33z
+
+docker-worker-with-iptables-fix:
+  workerImplementation: docker-worker
+  gcp:
+    image: projects/taskcluster-imaging/global/images/docker-worker-gcp-community-googlecompute-2020-04-24t16-52-52z
 
 generic-worker-win2012r2:
   workerImplementation: generic-worker

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -13,7 +13,7 @@ taskcluster:
     ci:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
-      imageset: docker-worker
+      imageset: docker-worker-with-iptables-fix
       cloud: gcp
       minCapacity: 1
       maxCapacity: 20

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -3,7 +3,7 @@ wpt:
     - github-team:web-platform-tests/admins
   workerPools:
     ci:
-      imageset: docker-worker
+      imageset: docker-worker-with-iptables-fix
       cloud: gcp
       maxCapacity: 80
       workerConfig:


### PR DESCRIPTION
I notice that the last image used here was not the `community` variant. Should we always be using the community variant here?
