### PR TITLE
Add d-w ci permissions to monorepo

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -183,7 +183,9 @@ taskcluster:
         - secrets:get:project/taskcluster/taskcluster-worker/stateless-dns
         - secrets:get:project/taskcluster/testing/docker-worker/ci-creds
         - secrets:get:project/taskcluster/testing/docker-worker/pulse-creds
-      to: repo:github.com/taskcluster/docker-worker:*
+      to:
+        - repo:github.com/taskcluster/docker-worker:* # This can be removed after 1635985 is resolved
+        - repo:github.com/taskcluster/taskcluster:branch:master # We leave this as master push only until we've audited permissions
 
     - grant:
         - secrets:get:project/taskcluster/monopacker/gcloud_service_account


### PR DESCRIPTION
This seems to have a lot more permissions and secrets available than our
normal monorepo tasks. docker-worker did not allow public PRs and
monorepo does. I'm decently sure that we can allow it but I want
to take a closer look first.


This supports taskcluster/taskcluster#2775