### PR TITLE
Bug 1636174 - enable docker-worker CI in taskcluster monorepo PRs

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -185,7 +185,7 @@ taskcluster:
         - secrets:get:project/taskcluster/testing/docker-worker/pulse-creds
       to:
         - repo:github.com/taskcluster/docker-worker:* # This can be removed after 1635985 is resolved
-        - repo:github.com/taskcluster/taskcluster:branch:master # We leave this as master push only until we've audited permissions
+        - repo:github.com/taskcluster/taskcluster:* # We leave this as master push only until we've audited permissions
 
     - grant:
         - secrets:get:project/taskcluster/monopacker/gcloud_service_account


### PR DESCRIPTION
Let's enable docker-worker CI on taskcluster monorepo PRs.

See [bug 1636174](https://bugzil.la/1636174) for context.