### PR TITLE
Add web-platform-tests/wpt-tc-checks to the checks/statuses workaround

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -186,6 +186,7 @@
   to:
     # Repositories that whish to use this work-around
     - repo:github.com/servo/servo:*
+    - repo:github.com/web-platform-tests/wpt-tc-checks:*
 
 # Allow the taskcluster team to handle the denylist
 - grant: notify:manage-denylist


### PR DESCRIPTION
WPT is moving towards using the checks API for TaskCluster. However we
also use a decision task and as per https://github.com/mozilla/community-tc-config/pull/129
this requires us to be added to the route workaround.

Note that wpt-tc-checks is a temporary clone of wpt being used as we
develop the TaskCluster Checks integration; ultimately this will be
replaced with the wpt repo itself.