### PR TITLE
Grant wpt-tc-checks the same scopes as wpt

### DIFF
--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -16,4 +16,6 @@ wpt:
         - queue:create-task:highest:proj-wpt/ci
         - docker-worker:capability:privileged
         - queue:scheduler-id:taskcluster-github
-      to: repo:github.com/web-platform-tests/wpt:*
+      to:
+        - repo:github.com/web-platform-tests/wpt:*
+        - repo:github.com/web-platform-tests/wpt-tc-checks:*


### PR DESCRIPTION
The wpt-tc-checks repo is a temporary* clone of wpt, used to develop our
necessary integration to switch from TaskCluster statuses to checks. To
let TaskCluster run on it, it needs the same grants as wpt.

* Temporary here means O(weeks); the hardest part of this project will
be fixing wpt.fyi to work with the checks API and I expect that to take
me a few weeks.