### PR TITLE
Add d-w test scopes for catlee

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -198,6 +198,9 @@ taskcluster:
         - repo:github.com/taskcluster/taskcluster:*
         - project:taskcluster:docker-worker-tester
 
+    - grant: assume:project:taskcluster:docker-worker-tester
+      to: login-identity:github/54458|catlee
+
     - grant:
         - secrets:get:project/taskcluster/monopacker/gcloud_service_account
         - secrets:get:project/taskcluster/monopacker/worker_secrets_yaml


### PR DESCRIPTION
```diff
--- current
+++ generated
@@ -919,16 +919,24 @@ Role=login-identity:github/485789|staktrace:
   Role=login-identity:github/485789|staktrace:
     roleId: login-identity:github/485789|staktrace
     description:
       *DO NOT EDIT* - This resource is configured automatically.


     scopes: - assume:project-admin:webrender

+  Role=login-identity:github/54458|catlee:
+    roleId: login-identity:github/54458|catlee
+    description:
+      *DO NOT EDIT* - This resource is configured automatically.
+
+
+    scopes: - assume:project:taskcluster:docker-worker-tester
+
   Role=project-admin:*:
     roleId: project-admin:*
     description:
       *DO NOT EDIT* - This resource is configured automatically.


     scopes:
       - assume:hook-id:project-<..>/*

```