### PR TITLE
Add docker-worker capability scopes necessary for fuzzing.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -54,6 +54,8 @@ fuzzing:
         - assume:hook-id:project-fuzzing/*
         - auth:create-role:hook-id:project-fuzzing/*
         - auth:update-role:hook-id:project-fuzzing/*
+        - docker-worker:capability:device:hostSharedMemory
+        - docker-worker:capability:privileged
         - hooks:modify-hook:project-fuzzing/*
         - hooks:trigger-hook:project-fuzzing/*
         - queue:create-task:highest:proj-fuzzing/*


### PR DESCRIPTION
- hostSharedMemory because running multiple ASan builds reliably in docker requires it
- privileged because some of our containers modify kernel parameters such as `kernel.core_pattern`