### PR TITLE
Add taskcluster-index scopes for FxR

### DIFF
--- a/config/projects/firefoxreality.yml
+++ b/config/projects/firefoxreality.yml
@@ -52,6 +52,10 @@ firefoxreality:
         - secrets:get:project/firefoxreality/fr/release-signing-token
       to:
         - repo:github.com/MozillaReality/FirefoxReality:release
+    - grant:
+        - queue:route:index.project.firefoxreality.*
+      to:
+        - repo:github.com/MozillaReality/FirefoxReality:branch:master
 
     # Firefox Reality PC
     - grant: secrets:get:project/firefoxreality/frpc/github-deploy-key


### PR DESCRIPTION
The end goal here is to have a magic link `https://community-tc.services.mozilla.com/tasks/index/project/firefoxreality/master` which would contain the artifacts from the latest master build. So this is for the task that is run on master branch upon pushes (lemme know if you think the scope or the role are not correct pls!)