### PR TITLE
Reduce minCapacity to 0 everywhere

### DIFF
--- a/config/projects/bergamot.yml
+++ b/config/projects/bergamot.yml
@@ -10,14 +10,14 @@ bergamot:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 5
+      maxCapacity: 10
     ci-windows:
       owner: nobody@mozilla.org
       emailOnError: false
       imageset: generic-worker-win2012r2
       cloud: aws
       minCapacity: 0
-      maxCapacity: 5
+      maxCapacity: 10
   grants:
     - grant:
         - queue:create-task:highest:proj-bergamot/ci-*

--- a/config/projects/bergamot.yml
+++ b/config/projects/bergamot.yml
@@ -10,14 +10,14 @@ bergamot:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 5
     ci-windows:
       owner: nobody@mozilla.org
       emailOnError: false
       imageset: generic-worker-win2012r2
       cloud: aws
-      minCapacity: 1
-      maxCapacity: 10
+      minCapacity: 0
+      maxCapacity: 5
   grants:
     - grant:
         - queue:create-task:highest:proj-bergamot/ci-*

--- a/config/projects/cia.yml
+++ b/config/projects/cia.yml
@@ -11,7 +11,7 @@ cia:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
+      minCapacity: 0
       maxCapacity: 10
   secrets:
     garbage/foo: true

--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -14,7 +14,7 @@ misc:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 20
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics

--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -13,8 +13,8 @@ misc:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 20
+      minCapacity: 0
+      maxCapacity: 10
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -27,8 +27,8 @@ relman:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 50
+      minCapacity: 0
+      maxCapacity: 10
       workerConfig:
         dockerConfig:
           allowPrivileged: true
@@ -37,32 +37,32 @@ relman:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 25
+      minCapacity: 0
+      maxCapacity: 10
       machineType: "zones/{zone}/machineTypes/n1-standard-1"
     compute-smaller:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 25
+      minCapacity: 0
+      maxCapacity: 10
       machineType: "zones/{zone}/machineTypes/n1-standard-2"
     compute-small:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 25
+      minCapacity: 0
+      maxCapacity: 10
       machineType: "zones/{zone}/machineTypes/n1-standard-4"
     compute-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 25
+      minCapacity: 0
+      maxCapacity: 10
       machineType: "zones/{zone}/machineTypes/n1-standard-8"
       workerConfig:
         genericWorker:
@@ -74,8 +74,8 @@ relman:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 25
+      minCapacity: 0
+      maxCapacity: 10
       machineType: "zones/{zone}/machineTypes/n1-standard-16"
       workerConfig:
         genericWorker:
@@ -87,6 +87,7 @@ relman:
       emailOnError: false
       imageset: deepspeech-win2012r2
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
   secrets:
     bugbug/deploy: true

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -28,7 +28,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 50
       workerConfig:
         dockerConfig:
           allowPrivileged: true
@@ -38,7 +38,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-1"
     compute-smaller:
       owner: mcastelluccio@mozilla.com
@@ -46,7 +46,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-2"
     compute-small:
       owner: mcastelluccio@mozilla.com
@@ -54,7 +54,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-4"
     compute-large:
       owner: mcastelluccio@mozilla.com
@@ -62,7 +62,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-8"
       workerConfig:
         genericWorker:
@@ -75,7 +75,7 @@ relman:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n1-standard-16"
       workerConfig:
         genericWorker:

--- a/config/projects/servo.yml
+++ b/config/projects/servo.yml
@@ -12,7 +12,7 @@ servo:
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       diskSizeGb: 100
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 40
     docker-untrusted:
       owner: servo-ops@mozilla.com
       emailOnError: false

--- a/config/projects/servo.yml
+++ b/config/projects/servo.yml
@@ -11,8 +11,8 @@ servo:
       cloud: gcp
       machineType: "zones/{zone}/machineTypes/n1-highcpu-16"
       diskSizeGb: 100
-      minCapacity: 2
-      maxCapacity: 40
+      minCapacity: 0
+      maxCapacity: 10
     docker-untrusted:
       owner: servo-ops@mozilla.com
       emailOnError: false

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -15,8 +15,8 @@ taskcluster:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
-      maxCapacity: 20
+      minCapacity: 0
+      maxCapacity: 10
 
     dw-ci:
       # docker-worker's CI requires the 'privileged' scope, so run
@@ -26,7 +26,7 @@ taskcluster:
       emailOnError: false
       imageset: docker-worker
       cloud: gcp
-      minCapacity: 1
+      minCapacity: 0
       maxCapacity: 10
       workerConfig:
         dockerConfig:
@@ -38,6 +38,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-win2012r2
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
 
     release:
@@ -46,6 +47,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-ubuntu-18-04
       cloud: aws
+      minCapacity: 0
       maxCapacity: 1
       workerConfig:
         genericWorker:
@@ -58,6 +60,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-ubuntu-18-04
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
       workerConfig:
         genericWorker:
@@ -72,6 +75,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-ubuntu-18-04-staging
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
       workerConfig:
         genericWorker:
@@ -83,6 +87,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-win2012r2
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
       workerConfig:
         genericWorker:
@@ -97,6 +102,7 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-win2012r2-staging
       cloud: aws
+      minCapacity: 0
       maxCapacity: 10
       workerConfig:
         genericWorker:

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -16,7 +16,7 @@ taskcluster:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 20
 
     dw-ci:
       # docker-worker's CI requires the 'privileged' scope, so run

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -5,7 +5,8 @@ wpt:
     ci:
       imageset: docker-worker
       cloud: gcp
-      maxCapacity: 80
+      minCapacity: 0
+      maxCapacity: 10
       workerConfig:
         dockerConfig:
           allowPrivileged: true

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -6,7 +6,7 @@ wpt:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 80
       workerConfig:
         dockerConfig:
           allowPrivileged: true


### PR DESCRIPTION
This will have the side-effect of slightly longer run times as we wait
for workers to be provisioned, but looking at the costs for time spent
idle, it would be hard to justify *not* making this change.

I've also explicitly added the minCapacity in some places where it was
missing (e.g. projects/taskcluster) instead of relying on the default
behavior. This will make it clearer when we look back when the change
was made.

While not stricly necessary, I've also reduced the maxCapacity for many
worker pools. The volume of jobs just doesn't justify the previous
requested max values.