### PR TITLE
Reduce default idle timeout to 1 second for all worker types

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -70,7 +70,7 @@ generic-worker-win2012r2:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -91,7 +91,7 @@ generic-worker-win2012r2-staging:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -110,7 +110,7 @@ generic-worker-ubuntu-18-04:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -129,7 +129,7 @@ generic-worker-ubuntu-18-04-podman:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -148,7 +148,7 @@ generic-worker-ubuntu-18-04-staging:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -167,7 +167,7 @@ deepspeech-win2012r2:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -186,7 +186,7 @@ deepspeech-win2012r2-b:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -204,7 +204,7 @@ deepspeech-win2012r2-gpu:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -222,7 +222,7 @@ deepspeech-win2012r2-gpu-b:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 90
+        idleTimeoutSecs: 1
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -68,7 +68,7 @@ relman:
         genericWorker:
           config:
             # Tasks using this worker pool are triggered rarely.
-            idleTimeoutSecs: 0
+            idleTimeoutSecs: 1
     compute-super-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -81,7 +81,7 @@ relman:
         genericWorker:
           config:
             # Tasks using this worker pool are triggered rarely.
-            idleTimeoutSecs: 0
+            idleTimeoutSecs: 1
     win2012r2:
       owner: mcastelluccio@mozilla.com
       emailOnError: false

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -75,9 +75,6 @@ taskcluster:
         genericWorker:
           config:
             runTasksAsCurrentUser: true
-            # Default timeout is 90s, but pool keeps emptying during working
-            # hours. Useful to keep alive to reduce pending time for CI tasks.
-            idleTimeoutSecs: 3600
 
     gw-ci-ubuntu-18-04-staging:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -102,9 +99,6 @@ taskcluster:
         genericWorker:
           config:
             runTasksAsCurrentUser: true
-            # Default timeout is 90s, but pool keeps emptying during working
-            # hours. Useful to keep alive to reduce pending time for CI tasks.
-            idleTimeoutSecs: 3600
 
     gw-ci-windows2012r2-amd64-staging:
       owner: taskcluster-notifications+workers@mozilla.com

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -421,7 +421,7 @@ def docker_worker(wp, **cfg):
     if wp.supports_worker_config():
         wp.merge_worker_config(
             WorkerPoolSettings.EXISTING_CONFIG,
-            {"shutdown": {"enabled": True, "afterIdleSeconds": 900,},},
+            {"shutdown": {"enabled": True, "afterIdleSeconds": 1,},},
         )
 
     wp.secret_tpl = {


### PR DESCRIPTION
Fixes #282 

Also increases the relman timeouts to 1 second to avoid previous hangs we've seen with a 0 second timeout.