### PR TITLE
Increase idle timeout to account for taskcluster/taskcluster#2969

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -70,7 +70,7 @@ generic-worker-win2012r2:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -91,7 +91,7 @@ generic-worker-win2012r2-staging:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -110,7 +110,7 @@ generic-worker-ubuntu-18-04:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -129,7 +129,7 @@ generic-worker-ubuntu-18-04-podman:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -148,7 +148,7 @@ generic-worker-ubuntu-18-04-staging:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -167,7 +167,7 @@ deepspeech-win2012r2:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -186,7 +186,7 @@ deepspeech-win2012r2-b:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -204,7 +204,7 @@ deepspeech-win2012r2-gpu:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:
@@ -222,7 +222,7 @@ deepspeech-win2012r2-gpu-b:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
         shutdownMachineOnIdle: true
-        idleTimeoutSecs: 1
+        idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true
         workerTypeMetadata:
           machine-setup:

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -68,7 +68,7 @@ relman:
         genericWorker:
           config:
             # Tasks using this worker pool are triggered rarely.
-            idleTimeoutSecs: 1
+            idleTimeoutSecs: 15
     compute-super-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -81,7 +81,7 @@ relman:
         genericWorker:
           config:
             # Tasks using this worker pool are triggered rarely.
-            idleTimeoutSecs: 1
+            idleTimeoutSecs: 15
     win2012r2:
       owner: mcastelluccio@mozilla.com
       emailOnError: false

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -421,7 +421,7 @@ def docker_worker(wp, **cfg):
     if wp.supports_worker_config():
         wp.merge_worker_config(
             WorkerPoolSettings.EXISTING_CONFIG,
-            {"shutdown": {"enabled": True, "afterIdleSeconds": 1,},},
+            {"shutdown": {"enabled": True, "afterIdleSeconds": 15,},},
         )
 
     wp.secret_tpl = {


### PR DESCRIPTION
Accounts for taskcluster/taskcluster#2969

```
! WorkerPool=proj-bergamot/ci-linux (changed: config)                                                    
! WorkerPool=proj-bergamot/ci-windows (changed: config)                                                  
! WorkerPool=proj-bors-ng/ci (changed: config)                                                           
! WorkerPool=proj-cia/ci (changed: config)
! WorkerPool=proj-deepspeech/ci (changed: config)                                                        
! WorkerPool=proj-deepspeech/win (changed: config)                                                       
! WorkerPool=proj-deepspeech/win-b (changed: config) 
! WorkerPool=proj-deepspeech/win-gpu (changed: config)  
! WorkerPool=proj-deepspeech/win-gpu-b (changed: config)                                                 
! WorkerPool=proj-firefoxreality/ci-linux (changed: config)
! WorkerPool=proj-fuzzing/ci (changed: config)
! WorkerPool=proj-fuzzing/generic-worker-ubuntu-18-04-podman (changed: config)
! WorkerPool=proj-git-cinnabar/ci (changed: config)
! WorkerPool=proj-git-cinnabar/win2012r2 (changed: config)
! WorkerPool=proj-l10n/ci (changed: config)
! WorkerPool=proj-misc/ci (changed: config)
! WorkerPool=proj-releng/ci (changed: config)
! WorkerPool=proj-relman/batch (changed: config)
! WorkerPool=proj-relman/ci (changed: config)
! WorkerPool=proj-relman/compute-large (changed: config)
! WorkerPool=proj-relman/compute-small (changed: config)
! WorkerPool=proj-relman/compute-smaller (changed: config)
! WorkerPool=proj-relman/compute-super-large (changed: config)
! WorkerPool=proj-relman/win2012r2 (changed: config) 
! WorkerPool=proj-servo/docker (changed: config)
! WorkerPool=proj-servo/docker-untrusted (changed: config)
! WorkerPool=proj-taskcluster/aws-test (changed: config)
! WorkerPool=proj-taskcluster/ci (changed: config)
! WorkerPool=proj-taskcluster/dw-ci (changed: config)
! WorkerPool=proj-taskcluster/gw-ci-ubuntu-18-04 (changed: config)
! WorkerPool=proj-taskcluster/gw-ci-ubuntu-18-04-staging (changed: config)
! WorkerPool=proj-taskcluster/gw-ci-windows2012r2-amd64 (changed: config)
! WorkerPool=proj-taskcluster/gw-ci-windows2012r2-amd64-staging (changed: config)
! WorkerPool=proj-taskcluster/release (changed: config)
! WorkerPool=proj-taskcluster/windows2012r2-amd64-ci (changed: config)
! WorkerPool=proj-telemetry/compute-small (changed: config)
! WorkerPool=proj-webrender/ci-linux (changed: config)
! WorkerPool=proj-wpt/ci (changed: config)
```