### PR TITLE
Create a client for running community worker version reports

### DIFF
--- a/config/projects/community-admin.yml
+++ b/config/projects/community-admin.yml
@@ -1,0 +1,6 @@
+community-admin:
+  clients:
+    audit-worker-versions:
+      scopes:
+        - queue:create-task:highest:*
+      description: "Client used for [worker version](https://github.com/taskcluster/community-history/tree/master/WorkerVersions) reports."

--- a/config/projects/community-admin.yml
+++ b/config/projects/community-admin.yml
@@ -2,5 +2,5 @@ community-admin:
   clients:
     audit-worker-versions:
       scopes:
-        - queue:create-task:highest:*
+        - queue:create-task:lowest:*
       description: "Client used for [worker version](https://github.com/taskcluster/community-history/tree/master/WorkerVersions) reports."


### PR DESCRIPTION
This client is used for running [worker version reports](https://github.com/taskcluster/community-history/tree/master/WorkerVersions/README.md) against our cluster.

It works by submitting tasks for all discovered (provisioner, worker type) pairs, excluding those known to be dynamically generated for CI tests, and then parsing the artifacts of the generated tasks.

Note, we can probably replace this eventually with an exchange of metadata when workers register with Worker Manager. However, for now this is a pragmatic approach to obtaining the data, and has the advantage that it also works for workers that do not interface with worker manager (such as manually provisioned workers that might not be yet using the static provider type). It allows you to detect workers attached to your cluster that you might otherwise be unaware of.

I'm working on an updated version that doesn't need the credentials, and can parse logs from existing tasks. This has the advantages of being faster (no need to wait for task to be claimed) and requiring no scopes, however it has the disadvantages that there may not be recent tasks for all worker types (so not all worker type versions can be inferred) and also that the data is less current (updated worker pools that haven't run tasks since they were updated will report the version they had when the most recent task ran) and also that it doesn't help you promptly/routinely find badly configured workers. In contrast, when routinely submitting tasks
for the worker report, you are essentially reporting on worker pool health. You see straight away if you have worker pools that are not able to claim tasks, because the task you created isn't getting claimed (e.g. large pending queues, misconfiguration of worker pool config, broken hardware, crashed machines, .....).

Therefore the approach of submitting tasks has many favourable side effects, so on the whole I prefer it, when there isn't a security concern about running this task on any worker.