### PR TITLE
Add a hook to trigger ci in domino-web-tests

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -30,7 +30,46 @@ fuzzing:
       cloud: aws
       minCapacity: 0
       maxCapacity: 10
-
+  hooks:
+    domino-web-tests:
+      description: Domino Web Tests trigger
+      owner: jkratzer@mozilla.com
+      emailOnError: true
+      bindings:
+        - exchange: exchange/taskcluster-github/v1/push
+          routingKeyPattern: primary.MozillaSecurity.domino
+        - exchange: exchange/taskcluster-github/v1/push
+          routingKeyPattern: primary.MozillaSecurity.GrIDL
+      task:
+        provisionerId: proj-fuzzing
+        workerType: ci
+        payload:
+          image: 'mozillasecurity/domino-web-tests:latest'
+          features:
+            taskclusterProxy: true
+          maxRunTime: 600
+        metadata:
+          name: Domino Web Tests
+          description: Domino Web Tests
+          owner: jkratzer@mozilla.com
+          source: 'https://github.com/MozillaSecurity/domino-web-tests'
+        expires:
+          $fromNow: 3 months
+        deadline:
+          $fromNow: 6 hours
+        scopes:
+          - queue:create-task:highest:proj-fuzzing/ci
+          - secrets:get:project/fuzzing/deploy-domino-web-tests
+          - secrets:get:project/fuzzing/deploy-domino
+          - secrets:get:project/fuzzing/deploy-gridl
+          - secrets:get:project/fuzzing/deploy-octo-private
+      triggerSchema:
+        type: object
+        properties:
+          branch:
+            type: string
+            default: master
+        additionalProperties: true
   grants:
     - grant:
         - queue:create-task:highest:proj-fuzzing/ci

--- a/generate/projects.py
+++ b/generate/projects.py
@@ -7,7 +7,7 @@
 import attr
 import re
 
-from tcadmin.resources import Role, Client, WorkerPool, Secret, Hook
+from tcadmin.resources import Role, Client, WorkerPool, Secret, Hook, Binding
 from .loader import loader, YamlDirectory
 from .workers import build_worker_pool
 from .grants import Grants
@@ -151,9 +151,6 @@ async def update_resources(resources, secret_values):
                 hookGroupId = "project-{}".format(project.name)
                 if project.externallyManaged.manage_individual_resources():
                     resources.manage("Hook={}/{}".format(hookGroupId, hookId))
-                assert (
-                    "bindings" not in info
-                ), "Please add support for bindings to use this feature"
                 resources.add(
                     Hook(
                         hookGroupId=hookGroupId,
@@ -163,7 +160,7 @@ async def update_resources(resources, secret_values):
                         owner=info["owner"],
                         emailOnError=info.get("emailOnError", False),
                         schedule=info.get("schedule", ()),
-                        bindings=info.get("bindings", ()),
+                        bindings=[Binding(**b) for b in info.get("bindings", [])],
                         task=info["task"],
                         triggerSchema=info.get("triggerSchema", {}),
                     )

--- a/generate/projects.py
+++ b/generate/projects.py
@@ -150,7 +150,7 @@ async def update_resources(resources, secret_values):
             for hookId, info in project.hooks.items():
                 hookGroupId = "project-{}".format(project.name)
                 if project.externallyManaged.manage_individual_resources():
-                    resources.manage("Hook={}/{}".format(hookGroupid, hookId))
+                    resources.manage("Hook={}/{}".format(hookGroupId, hookId))
                 assert (
                     "bindings" not in info
                 ), "Please add support for bindings to use this feature"


### PR DESCRIPTION
We want the CI for domino-web-tests to run on any change to the domino or gridl repositories in their respective master branches. This is intended to function as a dashboard for compatibility of ongoing development in the domino & gridl repos, but should not be blocking CI in either of those.

The `mozillasecurity/domino-web-tests:latest` image will just create a commit in the domino-web-tests repo to trigger CI via `.taskcluster.yml` in that repo.