### PR TITLE
Allow WPT to use built-in/success

### DIFF
--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -15,6 +15,7 @@ wpt:
   grants:
     - grant:
         - queue:create-task:highest:proj-wpt/ci
+        - queue:create-task:highest:built-in/success
         - docker-worker:capability:privileged
         - queue:scheduler-id:taskcluster-github
       to:


### PR DESCRIPTION
WPT intends to add a sink task to their dependency graph, as part of
their migration to the GitHub Checks API. As this task is a do-nothing,
it should use built-in/success, but this requires extended grants.