### PR TITLE
Correct typo in grant for WPT

### DIFF
--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -15,7 +15,7 @@ wpt:
   grants:
     - grant:
         - queue:create-task:highest:proj-wpt/ci
-        - queue:create-task:highest:built-in/succeed
+        - queue:create-task:highest:built-in/*
         - docker-worker:capability:privileged
         - queue:scheduler-id:taskcluster-github
       to:

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -15,7 +15,7 @@ wpt:
   grants:
     - grant:
         - queue:create-task:highest:proj-wpt/ci
-        - queue:create-task:highest:built-in/success
+        - queue:create-task:highest:built-in/succeed
         - docker-worker:capability:privileged
         - queue:scheduler-id:taskcluster-github
       to:


### PR DESCRIPTION
It's called `build-in/succeed`, not `built-in/success`, but in either case giving access
to all of built-in seems reasonable.

See https://docs.taskcluster.net/docs/reference/workers/built-in-workers