### PR TITLE
Fix to imageset.sh test whether instance type is supported in region

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -148,9 +148,7 @@ function aws_update {
     done
 
     # Create new base AMI, and apply user-data filter output, to get instance ID.
-    INSTANCE_ID="$(aws --region "${REGION}" ec2 run-instances --image-id "${AMI}" --key-name "${IMAGE_SET}_${REGION}" --security-groups "rdp-only" "ssh-only" --user-data "$(cat "${TEMP_SETUP_SCRIPT}")" --instance-type $(cat aws_base_instance_type) --block-device-mappings DeviceName=/dev/sda1,Ebs='{VolumeSize=75,DeleteOnTermination=true,VolumeType=gp2}' --instance-initiated-shutdown-behavior stop --client-token "${UNIQUE_NAME}" --query 'Instances[*].InstanceId' --output text 2>&1)"
-
-    if grep -Fq "not supported" "${INSTANCE_ID}"; then
+    if ! INSTANCE_ID="$(aws --region "${REGION}" ec2 run-instances --image-id "${AMI}" --key-name "${IMAGE_SET}_${REGION}" --security-groups "rdp-only" "ssh-only" --user-data "$(cat "${TEMP_SETUP_SCRIPT}")" --instance-type $(cat aws_base_instance_type) --block-device-mappings DeviceName=/dev/sda1,Ebs='{VolumeSize=75,DeleteOnTermination=true,VolumeType=gp2}' --instance-initiated-shutdown-behavior stop --client-token "${UNIQUE_NAME}" --query 'Instances[*].InstanceId' --output text 2>&1)"; then
         log "Cannot deploy in ${REGION} since instance type $(cat aws_base_instance_type) is not supported; skipping."
         return 0
     fi


### PR DESCRIPTION
The test whether an instance type was supported in a region was faulty, since `grep` reads from a file (such as stdin) but the check was passing the input as an argument.

This fix checks for a successful assignment, which in turn requires a 0 exit code for the `aws ec2 run-instances` command.