### PR TITLE
Log 'Secrets fetched' when fetched

### DIFF
--- a/generate/secret_values.py
+++ b/generate/secret_values.py
@@ -19,6 +19,7 @@ class SecretValues:
         print("Fetching secrets with passwordstore", file=sys.stderr)
         secret_values_yml = subprocess.check_output(["pass", PASSWORDSTORE_NAME])
         self.values = yaml.safe_load(secret_values_yml)
+        print("Secrets fetched", file=sys.stderr)
 
     def get(self, name, default=None):
         return self.values.get(name, default)


### PR DESCRIPTION
I use a yubikey to authenticate secrets access, an it's har to tell
whether I've sufficiently "touched" the yubikey to activate it,
particularly in the winter when my skin is dry.  This log message
will appear immediately after `pass` finishes, giving me the feedback
I need.