### PR TITLE
Check region secret exists prior to using

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -57,10 +57,13 @@ function deploy {
             log "Fetching secrets..."
             pass git pull
             for REGION in us-west-1 us-west-2 us-east-1; do
-              IMAGE_ID="$(cat "${IMAGE_SET}/aws.${REGION}.secrets" | sed -n 's/^AMI: *//p')"
-              yq w -i ../config/imagesets.yml "${IMAGE_SET}.aws.amis.${REGION}" "${IMAGE_ID}"
-              pass insert -m -f "community-tc/imagesets/${IMAGE_SET}/${REGION}" < "${IMAGE_SET}/aws.${REGION}.secrets"
-              pass insert -m -f "community-tc/imagesets/${IMAGE_SET}/${CLOUD}.${REGION}.id_rsa" < "${IMAGE_SET}/${CLOUD}.${REGION}.id_rsa"
+              # some regions may not have secrets if they do not support the required instance type
+              if [ -f "${IMAGE_SET}/aws.${REGION}.secrets" ]; then
+                IMAGE_ID="$(cat "${IMAGE_SET}/aws.${REGION}.secrets" | sed -n 's/^AMI: *//p')"
+                yq w -i ../config/imagesets.yml "${IMAGE_SET}.aws.amis.${REGION}" "${IMAGE_ID}"
+                pass insert -m -f "community-tc/imagesets/${IMAGE_SET}/${REGION}" < "${IMAGE_SET}/aws.${REGION}.secrets"
+                pass insert -m -f "community-tc/imagesets/${IMAGE_SET}/${CLOUD}.${REGION}.id_rsa" < "${IMAGE_SET}/${CLOUD}.${REGION}.id_rsa"
+              fi
             done
             log "Pushing new secrets..."
             pass git push


### PR DESCRIPTION
If a given aws region does not support the instance type required for a particular worker type, it is skipped. However, the `imageset.sh` script previously did not check if it was skipped before updating `config/imagesets.yml` and the password store secrets for a given (imageset, region).

Now `imageset.sh` no longer assumes an image is present in a region, and checks first, before applying changes that require the image to exist.