### PR TITLE
Switch deepspeech ci worker to n2d-highcpu-32

### DIFF
--- a/config/projects/deepspeech.yml
+++ b/config/projects/deepspeech.yml
@@ -12,7 +12,7 @@ deepspeech:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 96
-      machineType: "zones/{zone}/machineTypes/n1-standard-32"
+      machineType: "zones/{zone}/machineTypes/n2d-highcpu-32"
     win:
       owner: deepspeech@mozilla.com
       emailOnError: false


### PR DESCRIPTION
According to GCP docs:
 - n2d is faster, newer gen
 - highcpu is more balanced between CPU / RAM
 - we don't need the 120GB RAM of n1-standard-32
 - it's cheaper (price 1.52$ -> 0.998$ ; preemptive price 0.32$ -> 0.2415$)