### PR TITLE
[Cleanup] Remove old wpt-tc-checks repository

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -192,7 +192,6 @@
     # Repositories that whish to use this work-around
     - repo:github.com/servo/servo:*
     - repo:github.com/web-platform-tests/wpt:*
-    - repo:github.com/web-platform-tests/wpt-tc-checks:*
 
 # Allow the taskcluster team to handle the denylist
 - grant: notify:manage-denylist

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -20,4 +20,3 @@ wpt:
         - queue:scheduler-id:taskcluster-github
       to:
         - repo:github.com/web-platform-tests/wpt:*
-        - repo:github.com/web-platform-tests/wpt-tc-checks:*


### PR DESCRIPTION
wpt-tc-checks was a testing-ground repository for wpt as it moved to the
Taskcluster Checks integration. That work has now been completed, and
the repository is no longer needed.