### PR TITLE
Use n2-highcpu-32

### DIFF
--- a/config/projects/deepspeech.yml
+++ b/config/projects/deepspeech.yml
@@ -12,7 +12,7 @@ deepspeech:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 96
-      machineType: "zones/{zone}/machineTypes/n1-standard-32"
+      machineType: "zones/{zone}/machineTypes/n2-highcpu-32"
     win:
       owner: deepspeech@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This machine type:
 - allows for nested virtualization
 - is cheaper (1.5$ -> 1.1471$ ; 0.32$ -> 0.2776$)
 - newer and should be faster
 - is available in us-east1 and us-east4 zones

So I think it should be an easier switch for the moment than moving to n2d-highcpu-32