### PR TITLE
Revert "Use n2-highcpu-32"

### DIFF
--- a/config/projects/deepspeech.yml
+++ b/config/projects/deepspeech.yml
@@ -12,7 +12,7 @@ deepspeech:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 96
-      machineType: "zones/{zone}/machineTypes/n2-highcpu-32"
+      machineType: "zones/{zone}/machineTypes/n1-standard-32"
     win:
       owner: deepspeech@mozilla.com
       emailOnError: false


### PR DESCRIPTION
Reverts mozilla/community-tc-config#318 due to AWS errors so we can get tasks going again.