### PR TITLE
Create a separate configuration for bugbug, with admin from both sallt and cia teams

### DIFF
--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -1,0 +1,120 @@
+bugbug:
+  adminRoles:
+    - github-team:mozilla/sallt
+    - github-team:mozilla/cia
+  externallyManaged: true # bugbug deploys some hooks into this space
+  repos:
+    - github.com/mozilla/bugbug:*
+  workerPools:
+    ci:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 50
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
+    batch:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-1"
+    compute-smaller:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-2"
+    compute-small:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-4"
+    compute-large:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-8"
+      workerConfig:
+        genericWorker:
+          config:
+            # Tasks using this worker pool are triggered rarely.
+            idleTimeoutSecs: 15
+    compute-super-large:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n1-standard-16"
+      workerConfig:
+        genericWorker:
+          config:
+            # Tasks using this worker pool are triggered rarely.
+            idleTimeoutSecs: 15
+  secrets:
+    bugbug/deploy: true
+    bugbug/integration: true
+    bugbug/production: true
+    bugbug/testing: true
+  grants:
+    # all repos
+    - grant:
+        - queue:create-task:highest:proj-relman/*
+        - queue:route:statuses
+      to:
+        - repo:github.com/mozilla/bugbug:*
+
+    # all hooks
+    - grant:
+        - queue:scheduler-id:-
+        - queue:create-task:highest:proj-relman/*
+      to: hook-id:project-relman/*
+
+    # bugbug
+    - grant:
+        - docker-worker:cache:bugbug-*
+        - docker-worker:capability:privileged
+        - secrets:get:project/relman/bugbug/integration
+      to: project:relman:bugbug/build
+    - grant:
+        - secrets:get:project/relman/bugbug/deploy
+      to: project:relman:bugbug/deploy
+    - grant: assume:project:relman:bugbug/build
+      to: repo:github.com/mozilla/bugbug:*
+    # The build scopes for the tag will come from the previous rule.
+    - grant:
+        - assume:project:relman:bugbug/deploy
+        - assume:hook-id:project-relman/bugbug
+        - hooks:modify-hook:project-relman/bugbug
+      to: repo:github.com/mozilla/bugbug:tag:*
+    - grant:
+        - assume:project:relman:bugbug/build
+        - hooks:trigger-hook:project-relman/bugbug*
+        - queue:route:notify.email.*
+        - queue:route:notify.irc-channel.#bugbug.on-failed
+        - queue:route:index.project.relman.bugbug*
+        - queue:route:notify.pulse.route.project.relman.bugbug.*
+        - queue:route:project.relman.bugbug.*
+        - secrets:get:project/relman/bugbug/production
+        - auth:aws-s3:read-write:communitytc-bugbug/*
+      to: hook-id:project-relman/bugbug*
+    - grant:
+        - assume:project:relman:bugbug/deploy
+        - assume:hook-id:project-relman/bugbug-*
+        - hooks:modify-hook:project-relman/bugbug-*
+      to: hook-id:project-relman/bugbug


### PR DESCRIPTION
As suggested by @djmitche in #319, I'll split the patch in two: one to create the new bugbug project (to be landed right away) and one to remove bugbug from the relman project (to be landed after bugbug is updated to use the worker pool names from the new project).