### PR TITLE
Grant create-task for proj-bugbug instead of proj-relman in the bugbug project

### DIFF
--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -74,7 +74,7 @@ bugbug:
   grants:
     # all repos
     - grant:
-        - queue:create-task:highest:proj-relman/*
+        - queue:create-task:highest:proj-bugbug/*
         - queue:route:statuses
       to:
         - repo:github.com/mozilla/bugbug:*
@@ -82,7 +82,7 @@ bugbug:
     # all hooks
     - grant:
         - queue:scheduler-id:-
-        - queue:create-task:highest:proj-relman/*
+        - queue:create-task:highest:proj-bugbug/*
       to: hook-id:project-relman/*
 
     # bugbug


### PR DESCRIPTION
The other things (hook IDs, secret names, etc.) will keep "relman" in their name, so we don't need to change too many things.