### PR TITLE
Update proj-deepspeech/ci workers to 100GB disk

### DIFF
--- a/config/projects/deepspeech.yml
+++ b/config/projects/deepspeech.yml
@@ -13,6 +13,7 @@ deepspeech:
       minCapacity: 0
       maxCapacity: 96
       machineType: "zones/{zone}/machineTypes/n2-highcpu-32"
+      diskSizeGb: 100
     win:
       owner: deepspeech@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This is hopefully going to help avoid tensorflow linux cuda build failure like:
> Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/home/build-user/.bazel_cache/output/server/jvm.out')