### PR TITLE
Add schedulerId scope and fix scheduling

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -160,5 +160,6 @@ fuzzing:
         - queue:create-task:highest:proj-fuzzing/bugmon-processor
         - queue:get-artifact:project/fuzzing/bugmon/*
         - secrets:get:project/fuzzing/bz-api-key
+        - queue:scheduler-id:-
       to:
         - hook-id:project-fuzzing/bugmon

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -108,7 +108,7 @@ fuzzing:
           - queue:get-artifact:project/fuzzing/bugmon/*
           - secrets:get:project/fuzzing/bz-api-key
       schedule:
-        - "0 8 * * * *"
+        - "0 */8 * * *"
   grants:
     - grant:
         - queue:create-task:highest:proj-fuzzing/ci


### PR DESCRIPTION
Adds the required `queue:scheduler-id:-` scope and fixes the cron scheduling to run every 8 hours.