### PR TITLE
Add scopes for orion repository.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -276,6 +276,11 @@ fuzzing:
         - hook-id:project-fuzzing/grizzly-reduce-reset-error
     - grant:
         - docker-worker:capability:privileged
+        - queue:route:index.project.fuzzing.orion.*
+      to:
+        - repo:github.com/MozillaSecurity/orion:*
+    - grant:
+        - docker-worker:capability:privileged
         - queue:route:index.project.fuzzing.reduce-monitor.*
       to:
         - repo:github.com/MozillaSecurity/grizzly-reduce-tc:*


### PR DESCRIPTION
Orion is the repository used to build all of our docker images for fuzzing.