### PR TITLE
add djmitche/console-taskgraph to the misc project

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -70,6 +70,7 @@ misc:
       to:
         - repo:github.com/mozilla/*
         - repo:github.com/djmitche/taskchampion:*
+        - repo:github.com/djmitche/console-taskgraph:*
         - repo:github.com/marco-c/taskcluster_yml_validator:*
 
     # allow all mozilla projects, as well as all anyone with a github login, to


### PR DESCRIPTION
This has had a .taskcluster.yml for a long time, but not permission..  I just converted it to v1 for taskcluster/taskcluster#4098.