### PR TITLE
add blanket proj-misc access to the mozilla-services org

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -69,6 +69,7 @@ misc:
     - grant: queue:create-task:highest:proj-misc/ci
       to:
         - repo:github.com/mozilla/*
+        - repo:github.com/mozilla-services/*
         - repo:github.com/djmitche/taskchampion:*
         - repo:github.com/marco-c/taskcluster_yml_validator:*
 
@@ -78,6 +79,7 @@ misc:
       to:
         - login-identity:github/*
         - repo:github.com/mozilla/*
+        - repo:github.com/mozilla-services/*
 
     - grant:
         - queue:create-task:highest:proj-misc/ci


### PR DESCRIPTION
This org just got notices to move away from travis-ci, so let's make the transition to TC a little easier.