### PR TITLE
Allow rdp into proj-relman/win2012r2

### DIFF
--- a/config/aws.yml
+++ b/config/aws.yml
@@ -46,15 +46,19 @@ security_groups:
   us-west-1:
     no-inbound: sg-00c4014bc978171d5
     docker-worker: sg-0d2ff88f36a05b499
+    rdp: sg-0ddc5eae2e56a43c5
 
   us-west-2:
     no-inbound: sg-0659c2937ecbe7254
     docker-worker: sg-0f8a656368c567425
+    rdp: sg-0728e02d721b9d2c8
 
   us-east-1:
     no-inbound: sg-07f7d21a488e192c6
     docker-worker: sg-08fea1235cf66b102
+    rdp: sg-0f814fceb57681f0b
 
   us-east-2:
     no-inbound: sg-00a9d64b3595c5088
     docker-worker: sg-0388de36e2f30ced2
+    rdp: sg-0ba932a63b653dc19

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -45,6 +45,7 @@ relman:
       emailOnError: false
       imageset: deepspeech-win2012r2
       cloud: aws
+      securityGroup: rdp
       minCapacity: 0
       maxCapacity: 10
   secrets:


### PR DESCRIPTION
The project admins have the scopes for this but we have to
allow them in via security groups as well.

If this isn't actually desired for the whole pool for all time, let me know.
This is just using the `rdp` sg that was already existing in every region. It
allows all outbound traffic and only RDP on port 3389 for inbound.

cc @marco-c