### PR TITLE
Add CRATESIO_TOKEN

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -384,5 +384,6 @@ taskcluster:
       PYPI_PASSWORD: $taskcluster-release-pypi-password
       NPM_TOKEN: $taskcluster-release-npm-token
       GH_TOKEN: $taskcluster-release-gh-token
+      CRATESIO_TOKEN: $taskcluster-release-cratesio-token
     staging-release:
       GH_TOKEN: $taskcluster-staging-release-gh-token


### PR DESCRIPTION
Like the other package registries (aside from pypi), it looks like there's no good way to do a staging publish on crates.io.  There is staging.crates.io, but that appears to be staging for the deployment, not for users.  So this credential is only provided for prod.