### PR TITLE
[fuzzing] Increase max CI pool to 20 and grant cancel-task permission for project-fuzzing to fuzzing admins.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -25,7 +25,7 @@ fuzzing:
       imageset: docker-worker
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 20
       workerConfig:
         dockerConfig:
           allowPrivileged: true
@@ -408,6 +408,7 @@ fuzzing:
         - repo:github.com/MozillaSecurity/grizzly-reduce-tc:*
     - grant:
         - generic-worker:allow-rdp:proj-fuzzing/*
+        - queue:cancel-task:fuzzing/*
       to:
         - project-admin:fuzzing
     - grant:


### PR DESCRIPTION
The reason for the CI increase is that I'm using that queue now for all fuzzing decisions instead of running decisions in the fuzzing work queue.