### PR TITLE
Fix fuzzing Administrators scope. 

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -393,7 +393,7 @@ fuzzing:
         - docker-worker:capability:device:hostSharedMemory
         - docker-worker:capability:device:loopbackAudio
         - docker-worker:capability:privileged
-        - generic-worker:os-group:proj-fuzzing/*/Administrators
+        - generic-worker:os-group:proj-fuzzing/*
         - generic-worker:run-as-administrator:proj-fuzzing/*
         - hooks:modify-hook:project-fuzzing/*
         - hooks:trigger-hook:project-fuzzing/*


### PR DESCRIPTION
Wildcards are only valid against suffixes.