### PR TITLE
Fixes for hook telescope-periodic-v01

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -410,7 +410,7 @@ taskcluster:
     telescope-periodic-v01:
       description: >
         Periodically run a simple task, monitored by
-        [Telescope](https://github.com/mozilla-services/poucave).
+        [Telescope](https://telescope-demo.api.data.allizom.org).
       name: Periodic task for Telescope monitoring
       owner: jwhitlock@mozilla.com
       emailOnError: false
@@ -444,7 +444,7 @@ taskcluster:
             https://github.com/mozilla/community-tc-config/blob/main/config/projects/taskcluster.yml
           description: >
             A simple task, run every 15 minutes, monitored by
-            [Telescope](https://github.com/mozilla-services/poucave).
+            [Telescope](https://telescope-demo.api.data.allizom.org).
       triggerSchema:
         type: object
         properties: {}

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -440,6 +440,8 @@ taskcluster:
         metadata:
           name: telescope-periodic-v01
           owner: jwhitlock@mozilla.com
+          source: >-
+            https://github.com/mozilla/community-tc-config/blob/main/config/projects/taskcluster.yml
           description: >
             A simple task, run every 15 minutes, monitored by
             [Telescope](https://github.com/mozilla-services/poucave).


### PR DESCRIPTION
Set `metadata.source` to this repo. This change was needed to run the hook, and has already been applied to community-tc.

Change the Telescope URL in descriptions to https://telescope-demo.api.data.allizom.org. This change has not been applied yet.