### PR TITLE
Adding access token configuration for Telescope-Demo site

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -350,7 +350,22 @@ taskcluster:
       scopes:
         - "object:upload:taskcluster:taskcluster/test/*"
         - "object:download:taskcluster/test/*"
+    # A client for the Telescope-Demo site
+    # Access token is stored in GCP Secret Manager
+    # GCP project is mozilla-api-stage
+    telescope-demo-client:
+      description: >
+        This is a temporary client created by SysEng for the Telescope-demo environment
 
+      scopes:
+        - assume:hook-id:project-taskcluster/*
+        - hooks:modify-hook:project-taskcluster/*
+        - index:insert-task:project.taskcluster.*
+        - queue:create-task:highest:proj-taskcluster/*
+        - queue:route:index.project.taskcluster.*
+        - queue:scheduler-id:-
+        - secrets:get:project/taskcluster/*
+        - secrets:set:project/taskcluster/*
   secrets:
     # client_id/access_token for project/taskcluster/testing/docker-worker/ci-creds
     testing/docker-worker/ci-creds: true


### PR DESCRIPTION
This is for the Telescope demo site, adding a client and associated access token. 

GCP Project: mozilla-api-stage
Telescope demo site will be able to make authenticated calls to taskcluster