### PR TITLE
Use `shutdown -h now` instead of `shutdown now`

### DIFF
--- a/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
@@ -101,4 +101,4 @@ end_time="$(date '+%s')"
 echo "UserData execution took: $(($end_time-$start_time)) seconds"
 
 # shutdown so that instance can be snapshotted
-shutdown now
+shutdown -h now

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -111,4 +111,4 @@ end_time="$(date '+%s')"
 echo "UserData execution took: $(($end_time-$start_time)) seconds"
 
 # shutdown so that instance can be snapshotted
-shutdown now
+shutdown -h now

--- a/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
@@ -105,4 +105,4 @@ end_time="$(date '+%s')"
 echo "UserData execution took: $(($end_time-$start_time)) seconds"
 
 # shutdown so that instance can be snapshotted
-shutdown now
+shutdown -h now


### PR DESCRIPTION
In 699fd1f8f62b62e2571dfd6ad3724e4fb3fd3e31 we needed to use `shutdown -h now` instead of `shutdown now`, so reflecting that here to be safe.