### PR TITLE
Default ec2 instance type m4.2xlarge => m5.2xlarge

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -319,7 +319,7 @@ def aws(
     *,
     image_set=None,
     regions=None,
-    instanceTypes={"m4.2xlarge": 1},
+    instanceTypes={"m5.2xlarge": 1},
     securityGroup="no-inbound",
     minCapacity=0,
     maxCapacity=None,


### PR DESCRIPTION
m4.2xlarge is pretty old, and is often unavailable, therefore changing default instance type to m5.2xlarge. See also https://github.com/mozilla/community-tc-config/pull/428#issuecomment-929066262.



Originally I [intended to update](https://github.com/mozilla/community-tc-config/pull/428#issuecomment-930130397) the hardcoded [EC2 availability zones](https://github.com/mozilla/community-tc-config/blob/266a6c02d7d3e6bf86bd192a986355c18266fb23/generate/workers.py#L365-L371)/[GCP zones](https://github.com/mozilla/community-tc-config/blob/266a6c02d7d3e6bf86bd192a986355c18266fb23/generate/workers.py#L269-L278) in this PR. However, I've since seen that I can use [`aws ec2 describe-instance-types`](https://docs.aws.amazon.com/ko_kr/cli/latest/reference/ec2/describe-instance-types.html) and [`gcloud compute machine-types list`](https://cloud.google.com/sdk/gcloud/reference/compute/machine-types/list) to determine if an instance type / machine type is available in a given EC2 availability zone / GCP zone, which is a bit more work, but should require less maintenance. Therefore I'll put that in its own PR.