### PR TITLE
Ensure yq version 3 is used by imageset.sh

### DIFF
--- a/imagesets/README.md
+++ b/imagesets/README.md
@@ -117,7 +117,7 @@ All of the following tools must be available in the `PATH`:
   * `tr`
   * `which`
   * `xargs`
-  * `yq` **version 3** (version 4 not supported)
+  * `yq` **version 3** (version 4 is [backwardly incompatible](https://mikefarah.gitbook.io/yq/upgrading-from-v3))
 
 ## Post image set building steps
 

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -26,6 +26,15 @@ function deploy {
         fi
     done
 
+    if ! yq --version 2>&1 | grep -q 'version 3\.'; then
+        log "${0} requires yq version 3 in your PATH, but you have:" >&2
+        log "    $(which yq)" >&2
+        log "    $(yq --version 2>&1)" >&2
+        exit 69
+    else
+        log "  \xE2\x9C\x94 yq is version 3"
+    fi
+
     log "Checking inputs..."
 
     if [ "${#}" -ne 3 ]; then

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -30,6 +30,8 @@ function deploy {
         log "${0} requires yq version 3 in your PATH, but you have:" >&2
         log "    $(which yq)" >&2
         log "    $(yq --version 2>&1)" >&2
+        log "See https://mikefarah.gitbook.io/yq/upgrading-from-v3 about backward incompatibility of version 4 and higher."
+        log "Note, an alternative solution is to upgrade this script to use v4 syntax and rebuild/publish docker container etc."
         exit 69
     else
         log "  \xE2\x9C\x94 yq is version 3"


### PR DESCRIPTION
This requirement was [already documented](https://github.com/mozilla/community-tc-config/blob/3ae9b2c05e540a9a2f35336d1058da2e7c8fe8b2/imagesets/README.md?plain=1#L120), but not included in checks.