### PR TITLE
Add region us-east-2 for building AWS EC2 worker AMIs

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -79,9 +79,10 @@ generic-worker-win2012r2-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-082c2d64e8209bb0f
-      us-west-1: ami-055c72aff254354fa
-      us-west-2: ami-0820db6bf4ff3c943
+      us-east-1: ami-0645f31a90010e574
+      us-west-1: ami-01ecc4a44b76f7863
+      us-west-2: ami-0f984fd4c43810fe0
+      us-east-2: ami-042978a5ec2271521
   workerConfig:
     genericWorker:
       config:
@@ -92,7 +93,7 @@ generic-worker-win2012r2-staging:
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
-            script: https://github.com/mozilla/community-tc-config/blob/590a9c7d29a185a706ed478845f06d7e95f77400/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+            script: https://github.com/mozilla/community-tc-config/blob/0037422535df55cf1d66ba744af6d800bd48fbd0/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
 generic-worker-ubuntu-18-04:
   workerImplementation: generic-worker
   aws:

--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -52,7 +52,7 @@ docker-worker:
   gcp:
     image: projects/taskcluster-imaging/global/images/docker-worker-5nrfllxteqxz1yrln5kx
   aws:
-    # built with the `docker_worker_community_aws` builder in monopacker
+    # originally built with the `docker_worker_community_aws` builder in monopacker
     amis:
       us-east-1: ami-09933aeacc9b3c2ba
       us-west-1: ami-036c57fcae9304ec3
@@ -80,9 +80,9 @@ generic-worker-win2012r2-staging:
   aws:
     amis:
       us-east-1: ami-0645f31a90010e574
+      us-east-2: ami-042978a5ec2271521
       us-west-1: ami-01ecc4a44b76f7863
       us-west-2: ami-0f984fd4c43810fe0
-      us-east-2: ami-042978a5ec2271521
   workerConfig:
     genericWorker:
       config:

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -78,10 +78,10 @@ function deploy {
               log "Need AWS credentials..."
               eval $(signin-aws)
             fi
-            echo us-west-1 118 246 us-west-2 199 220 us-east-1 4 200 | xargs -P3 -n3 "${0}" process-region "${CLOUD}_${ACTION}"
+            echo us-west-1 118 246 us-west-2 199 220 us-east-1 4 200 us-east-2 33 210 | xargs -P4 -n3 "${0}" process-region "${CLOUD}_${ACTION}"
             log "Fetching secrets..."
             pass git pull
-            for REGION in us-west-1 us-west-2 us-east-1; do
+            for REGION in us-west-1 us-west-2 us-east-1 us-east-2; do
               # some regions may not have secrets if they do not support the required instance type
               if [ -f "${IMAGE_SET}/aws.${REGION}.secrets" ]; then
                 IMAGE_ID="$(cat "${IMAGE_SET}/aws.${REGION}.secrets" | sed -n 's/^AMI: *//p')"


### PR DESCRIPTION
Adding us-east-2 to aws regions to build AMIs in.

Fixes #438.