### PR TITLE
Default EC2 instance types: m4.2xlarge and m5.2xlarge

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -369,7 +369,10 @@ def aws(
     *,
     image_set=None,
     regions=None,
-    instanceTypes={"m5.2xlarge": 1},
+    instanceTypes={
+        "m4.2xlarge": 1,
+        "m5.2xlarge": 1,
+    },
     securityGroup="no-inbound",
     minCapacity=0,
     maxCapacity=None,


### PR DESCRIPTION
Originated from https://github.com/mozilla/community-tc-config/issues/438#issuecomment-940069657.