### PR TITLE
Allow repo mozilla/mozci to index tasks for Docker image publication

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -204,3 +204,9 @@ relman:
     # grcov
     - grant: secrets:get:project/relman/grcov/deploy
       to: repo:github.com/mozilla/grcov:tag:*
+
+    # mozci
+    - grant:
+        - queue:route:index.project.mozci.docker-pr.*
+        - queue:route:index.project.mozci.docker.*
+      to: repo:github.com/mozilla/mozci:*


### PR DESCRIPTION
This is needed for https://github.com/mozilla/mozci/pull/546 where we want to build a Docker image on Taskcluster, publish it as an artifact, then index the task so it can later be used to run new tasks.