### PR TITLE
Allow the proj-taskcluster/ci worker for json-e

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -183,6 +183,10 @@ taskcluster:
         - repo:github.com/taskcluster/taskcluster:tag:v*
 
     - grant:
+        - queue:create-task:highest:proj-taskcluster/ci
+      to: repo:github.com/json-e/json-e:*
+
+    - grant:
         # pushes to json-e main can read secrets for deploying the site
         - secrets:get:project/taskcluster/json-e-deploy
         # ..and notify on failure


### PR DESCRIPTION
This worker is allowed to repos taskcluster/*, so I missed it in the
earlier PR.