### PR TITLE
Setup project mozci with decision task hook

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -1,0 +1,85 @@
+mozci:
+  adminRoles:
+    - github-team:mozilla/compiler-and-development-tools
+  repos:
+    - github.com/mozilla/mozci:*
+  workerPools:
+    ci:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 50
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
+    compute-smaller:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n2-standard-2"
+    compute-small:
+      owner: mcastelluccio@mozilla.com
+      emailOnError: false
+      imageset: docker-worker
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 25
+      machineType: "zones/{zone}/machineTypes/n2-standard-4"
+  grants:
+    # all repos
+    - grant:
+        - queue:create-task:highest:proj-mozci/*
+        - queue:route:statuses
+      to:
+        - repo:github.com/mozilla/mozci:*
+
+    # all hooks
+    - grant:
+        - queue:scheduler-id:-
+        - queue:create-task:highest:proj-mozci/*
+      to: hook-id:project-mozci/*
+
+    # Routes for mozci docker images
+    - grant:
+        - queue:route:index.project.mozci.docker-pr.*
+        - queue:route:index.project.mozci.docker.*
+      to: repo:github.com/mozilla/mozci:*
+
+    - grant:
+        # Allow decision task to create children tasks
+        - queue:create-task:project:none
+
+        # Children tasks are indexed
+        - queue:route:index.project.mozci.classification.*
+
+      to: hook-id:project-mozci/decision-task-testing
+
+  hooks:
+    decision-task-testing:
+      description: Run mozci classification tasks for new pushes
+      owner: mcastelluccio@mozilla.com
+      emailOnError: true
+      schedule: ['*/15 * * * *'] # every 15 minutes
+      task:
+        provisionerId: proj-mozci
+        workerType: compute-smaller
+        payload:
+          image:
+            type: task-image
+            path: public/mozci.tar.zst
+            taskId: project.mozci.docker.branch.master
+          features:
+            taskclusterProxy: true
+          command:
+            - decision
+          maxRunTime: 1800
+        metadata:
+          name: mozci decision task - testing
+          description: mozci decision task
+          owner: mcastelluccio@mozilla.com
+          source: https://github.com/mozilla/mozci

--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -55,7 +55,7 @@ mozci:
         - queue:create-task:project:none
 
         # Children tasks are indexed
-        - queue:route:index.project.mozci.classification.*
+        - queue:route:index.project.mozci.*
 
       to: hook-id:project-mozci/decision-task-testing
 

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -19,7 +19,6 @@ relman:
     - github.com/mozilla/stab-crashes:*
     - github.com/mozilla/grcov:*
     - github.com/mozilla/adr:*
-    - github.com/mozilla/mozci:*
   clients:
     bugbug/code-review-production:
       scopes:
@@ -97,7 +96,6 @@ relman:
         - repo:github.com/mozilla/stab-crashes:*
         - repo:github.com/mozilla/grcov:*
         - repo:github.com/mozilla/adr:*
-        - repo:github.com/mozilla/mozci:*
 
     # all hooks
     - grant:
@@ -204,9 +202,3 @@ relman:
     # grcov
     - grant: secrets:get:project/relman/grcov/deploy
       to: repo:github.com/mozilla/grcov:tag:*
-
-    # mozci
-    - grant:
-        - queue:route:index.project.mozci.docker-pr.*
-        - queue:route:index.project.mozci.docker.*
-      to: repo:github.com/mozilla/mozci:*


### PR DESCRIPTION
Needed for https://github.com/mozilla/mozci/pull/552

This merge requests creates a dedicated project for [mozci](https://github.com/mozilla/mozci/) to:
- run its CI tasks for the github repository (set before in project `relman`)
- create a new hook with a cron schedule to run a decision task
   - uses a Docker image stored as an artifact on an [indexed task](https://community-tc.services.mozilla.com/tasks/index/project.mozci.docker.branch/master)
   - runs every 15 minutes
   - needs scopes to create children tasks
   - needs scope to index children task ( as `project.mozci.classification.push.ID`)