### PR TITLE
Fix syntax to use indexed docker image in mozci hook

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -70,9 +70,9 @@ mozci:
         workerType: compute-smaller
         payload:
           image:
-            type: task-image
+            type: indexed-image
             path: public/mozci.tar.zst
-            taskId: project.mozci.docker.branch.master
+            namespace: project.mozci.docker.branch.master
           features:
             taskclusterProxy: true
           command:


### PR DESCRIPTION
I tested that syntax on a [sample task](https://community-tc.services.mozilla.com/tasks/B1x_y123SPCGRFtYpJvCrQ/runs/0/logs/live/public/logs/live.log)