### PR TITLE
Assume defined scopes for hook project-mozci/decision-task-testing

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -78,6 +78,8 @@ mozci:
           command:
             - decision
           maxRunTime: 1800
+        scopes:
+          - assume:hook-id:project-mozci/decision-task-testing
         metadata:
           name: mozci decision task - testing
           description: mozci decision task


### PR DESCRIPTION
The hook [project-mozci/decision-task-testing](https://community-tc.services.mozilla.com/hooks/project-mozci/decision-task-testing) was missing the previously requested scopes: @marco-c was able to edit the configuration to test that change before creating this PR.

The hook now [runs cleanly](https://community-tc.services.mozilla.com/tasks/groups/JG1XWX3zQLKaKzcA1ysZsQ) with this change