### PR TITLE
Grant access to docker-worker cache for mozci decision tasks

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -57,6 +57,9 @@ mozci:
         # Children tasks are indexed
         - queue:route:index.project.mozci.*
 
+        # Children tasks need to share a common cache
+        - docker-worker:cache:mozci-classifications-testing
+
       to: hook-id:project-mozci/decision-task-testing
 
   hooks:

--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -30,6 +30,8 @@ mozci:
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-4"
+  secrets:
+    mozci/testing: true
   grants:
     # all repos
     - grant:
@@ -60,6 +62,8 @@ mozci:
         # Children tasks need to share a common cache
         - docker-worker:cache:mozci-classifications-testing
 
+        # Children tasks read their configuration from taskcluster
+        - secrets:get:project/mozci/testing
       to: hook-id:project-mozci/decision-task-testing
 
   hooks:


### PR DESCRIPTION
Needed for https://github.com/mozilla/mozci/issues/564

I'm setting up a shared cache for the mozci classification tasks. Pickled payloads using [cachy](https://github.com/sdispater/cachy/) will be stored on that cache : we do not expect a lot of disk storage needed (we do not clone MC ...)

I also need access to a secret in order to configure cache settings for the different tasks.