### PR TITLE
Switch mozci decision task to autoland

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -84,6 +84,7 @@ mozci:
             taskclusterProxy: true
           command:
             - decision
+            - autoland
           maxRunTime: 1800
         scopes:
           - assume:hook-id:project-mozci/decision-task-testing


### PR DESCRIPTION
This MR will update the mozci testing hook to use pushes from autoland instead of mozilla-central.