### PR TITLE
Fix project/mozci/testing secret declaration

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -31,7 +31,7 @@ mozci:
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-4"
   secrets:
-    mozci/testing: true
+    testing: true
   grants:
     # all repos
     - grant:


### PR DESCRIPTION
In order to preserve the `project/mozci/testing` secret, we do not need to prefix by the project's name