### PR TITLE
Update mozci monitoring hook command

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -120,8 +120,9 @@ mozci:
           env:
             TASKCLUSTER_SECRET: project/mozci/testing
           command:
+            - push
             - classify-eval
-            - "--from=1 day"
+            - "--from=1 days ago"
             - --send-email
           maxRunTime: 1800
         scopes:


### PR DESCRIPTION
As we are wrapping up [initial work](https://github.com/mozilla/mozci/pull/623#pullrequestreview-870579677) on the mozci monitoring hook, we noticed that the command defined here needs some changes.

