### PR TITLE
Allow gw for docker-exec-websocket-server, -client

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -299,6 +299,12 @@ taskcluster:
       to:
         - hook-id:project-taskcluster/telescope-periodic-v01
 
+    - grant:
+        - queue:create-task:medium:proj-taskcluster/gw-ci-ubuntu-18-04
+      to:
+        - repo:github.com/taskcluster/docker-exec-websocket-server:*
+        - repo:github.com/taskcluster/docker-exec-websocket-client:*
+
   clients:
     smoketests:
       scopes:


### PR DESCRIPTION
Allow two new projects to use the generic worker gw-ci-ubuntu-18-04:

* taskcluster/docker-exec-websocket-server
* taskcluster/docker-exec-websocket-client