### PR TITLE
Use correct mozci date parameter in date hook

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -122,7 +122,7 @@ mozci:
           command:
             - push
             - classify-eval
-            - "--from=1 days ago"
+            - "--from-date=1 days ago"
             - --send-email
           maxRunTime: 1800
         scopes:


### PR DESCRIPTION
Sorry, again a fix on the mozci hook, we had a communication issue on that parameter :cry: 

Needed to fix the current error on the hook https://community-tc.services.mozilla.com/tasks/QmrFXEhySYWroLSi6C9cvg/runs/0/logs/public/logs/live.log