### PR TITLE
Enable mozci classification tasks to send emails and matrix notifications

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -64,6 +64,13 @@ mozci:
 
         # Children tasks read their configuration from taskcluster
         - secrets:get:project/mozci/testing
+
+        # Children tasks are able to send emails
+        - notify:email:*
+
+        # Children tasks are able to send notifications
+        # to code sherriffs through Matrix
+        - notify:matrix-room:!sheriff-notifications:mozilla.org
       to: hook-id:project-mozci/decision-task-testing
 
     - grant:


### PR DESCRIPTION
Needed for https://github.com/mozilla/mozci/issues/625

We now want to send notifications (emails and matrix notifications) when a mozci classification for a push evolves or is Bad.