### PR TITLE
Set CLI environments for mozci hooks

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -121,6 +121,7 @@ mozci:
           command:
             - decision
             - autoland
+            - --environment=testing
           maxRunTime: 1800
         scopes:
           - assume:hook-id:project-mozci/decision-task-testing
@@ -152,6 +153,7 @@ mozci:
             - classify-eval
             - "--from-date=1 days ago"
             - --send-email
+            - --environment=testing
           maxRunTime: 1800
         scopes:
           - assume:hook-id:project-mozci/monitoring-testing
@@ -179,6 +181,7 @@ mozci:
           command:
             - decision
             - autoland
+            - --environment=production
           maxRunTime: 1800
         scopes:
           - assume:hook-id:project-mozci/decision-task-production
@@ -210,6 +213,7 @@ mozci:
             - classify-eval
             - "--from-date=1 days ago"
             - --send-email
+            - --environment=production
           maxRunTime: 1800
         scopes:
           - assume:hook-id:project-mozci/monitoring-production


### PR DESCRIPTION
Followup on https://github.com/mozilla/community-tc-config/pull/465 to enable the correct environment on each hooks