### PR TITLE
Grant rights to Mozci classification tasks to email analysis team on fail

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -60,6 +60,10 @@ mozci:
         # Children tasks are indexed
         - queue:route:index.project.mozci.*
 
+        # When a child task (prod or testing) is failing on TC,
+        # an email should be sent to the analysis team
+        - queue:route:notify.email.release-mgmt-analysis@mozilla.com.on-failed
+
         # Children tasks are able to send emails
         - notify:email:*
 


### PR DESCRIPTION
Now we not only want our tasks to be able to notify at runtime, but we also want to be notified when one of them fails on TaskCluster to address the issue. Related to https://github.com/mozilla/mozci/pull/668 and specifically to the [changes in this file](https://github.com/mozilla/mozci/pull/668/files#diff-8cac448572228d01096cdf0ff1974ce59c381308c18b1c094b0e0f4954a759c5R89).