### PR TITLE
Upgrade all generic-worker worker pools to v44.8.4

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,17 +8,17 @@ tasks:
     repo:
       $if: 'tasks_for == "github-push"'
       then:
-        git_url: ${event.repository.url}
+        clone_url: ${event.repository.url}
         url: ${event.repository.url}
         ref: ${event.after}
       else:
         $if: 'tasks_for == "github-pull-request"'
         then:
-          git_url: ${event.pull_request.head.repo.git_url}
+          clone_url: ${event.pull_request.head.repo.clone_url}
           url: ${event.pull_request.head.repo.url}
           ref: ${event.pull_request.head.sha}
         else:
-          git_url: ${event.repository.url}
+          clone_url: ${event.repository.url}
           url: ${event.repository.url}
           ref: ${event.release.tag_name}
   in:
@@ -31,7 +31,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.git_url} repo &&
+              git clone ${repo.clone_url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
@@ -45,7 +45,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.git_url} repo &&
+              git clone ${repo.clone_url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
@@ -58,7 +58,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.git_url} repo &&
+              git clone ${repo.clone_url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&

--- a/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
+++ b/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
@@ -103,7 +103,7 @@ Start-Process "msiexec" -ArgumentList "/i C:\BinScopeSetup.msi /quiet" -Wait -No
 New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound -LocalPort 60022 -Protocol TCP -Action Allow
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.11.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.11.5.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")
 Start-Process "C:\Git-2.16.2-64-bit.exe" -ArgumentList "/VERYSILENT /LOG=C:\git_install.log /NORESTART /SUPPRESSMSGBOXES" -Wait -NoNewWindow
 $client.DownloadFile("http://aka.ms/downloadazcopy", "C:\AZCopy.msi")

--- a/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
+++ b/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
@@ -103,7 +103,7 @@ Start-Process "msiexec" -ArgumentList "/i C:\BinScopeSetup.msi /quiet" -Wait -No
 New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound -LocalPort 60022 -Protocol TCP -Action Allow
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.8.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.8.windows-amd64.zip"
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")
 Start-Process "C:\Git-2.16.2-64-bit.exe" -ArgumentList "/VERYSILENT /LOG=C:\git_install.log /NORESTART /SUPPRESSMSGBOXES" -Wait -NoNewWindow
 $client.DownloadFile("http://aka.ms/downloadazcopy", "C:\AZCopy.msi")

--- a/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
+++ b/imagesets/firefoxreality-1-win10-64/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "32.0.0"
+$TASKCLUSTER_VERSION = "44.8.4"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Get-ChildItem Env: | Out-File "C:\install_env.txt"

--- a/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-podman/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v32.0.0'
+TASKCLUSTER_VERSION='v44.8.4'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -46,7 +46,7 @@ systemctl status docker | grep "Started Docker Application Container Engine"
 usermod -aG docker ubuntu
 
 # build generic-worker/livelog/start-worker/taskcluster-proxy from ${TASKCLUSTER_REF} commit / branch / tag etc
-retry curl -L 'https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz' > go.tar.gz
+retry curl -L 'https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz' > go.tar.gz
 tar xvfz go.tar.gz -C /usr/local
 export HOME=/root
 export GOPATH=~/go

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -46,7 +46,7 @@ systemctl status docker | grep "Started Docker Application Container Engine"
 usermod -aG docker ubuntu
 
 # build generic-worker/livelog/start-worker/taskcluster-proxy from ${TASKCLUSTER_REF} commit / branch / tag etc
-retry curl -L 'https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz' > go.tar.gz
+retry curl -L 'https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz' > go.tar.gz
 tar xvfz go.tar.gz -C /usr/local
 export HOME=/root
 export GOPATH=~/go

--- a/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_REF='v32.0.0'
+TASKCLUSTER_REF='v44.8.4'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-18-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v32.0.0'
+TASKCLUSTER_VERSION='v44.8.4'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -171,7 +171,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.11.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.11.5.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "32.0.0"
+$TASKCLUSTER_VERSION = "44.8.4"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2-staging/bootstrap.ps1
@@ -171,7 +171,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.8.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.8.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2012r2/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2/bootstrap.ps1
@@ -171,7 +171,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.11.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.11.5.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2012r2/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2/bootstrap.ps1
@@ -171,7 +171,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.8.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.8.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2012r2/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "44.8.3"
+$TASKCLUSTER_VERSION = "44.8.4"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/imagesets/generic-worker-win2016/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "32.0.0"
+$TASKCLUSTER_VERSION = "44.8.4"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -132,7 +132,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.11.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.11.5.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.6.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.6.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2016/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016/bootstrap.ps1
@@ -132,7 +132,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.8.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.8.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/generic-worker-win2016/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016/bootstrap.ps1
@@ -132,7 +132,7 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound
 
 # install go (not required, but useful)
 md "C:\gopath"
-Expand-ZIPFile -File "C:\go1.17.6.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.6.windows-amd64.zip"
+Expand-ZIPFile -File "C:\go1.17.7.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.17.7.windows-amd64.zip"
 
 # install git
 $client.DownloadFile("https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe", "C:\Git-2.16.2-64-bit.exe")

--- a/imagesets/relman-win2012r2/bootstrap.ps1
+++ b/imagesets/relman-win2012r2/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "32.0.0"
+$TASKCLUSTER_VERSION = "44.8.4"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
Upgrade remaining generic-worker worker pools to v44.8.4.

Note, after this lands, worker pools will still need to be rolled out (machine images built) so merging won't automatically trigger a deploy, currently (future work).