### PR TITLE
Fix imageset generation on macOS

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -135,9 +135,10 @@ generic-worker-ubuntu-18-04-staging:
   workerImplementation: generic-worker
   aws:
     amis:
-      us-east-1: ami-0bfbcea1e13dfdb8a
-      us-west-1: ami-0b9d053fd6a809c8c
-      us-west-2: ami-0f402ebee06e1d5c9
+      us-east-1: ami-06bf86c730ce8a38d
+      us-west-1: ami-097c7e3654aad8eb6
+      us-west-2: ami-034872d3c9919b020
+      us-east-2: ami-0944cf237a1b66d99
   workerConfig:
     genericWorker:
       config:
@@ -148,7 +149,7 @@ generic-worker-ubuntu-18-04-staging:
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
-            script: https://github.com/mozilla/community-tc-config/blob/bdb75beb514c89526422ee45a3de2f421a12c92e/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.ps1
+            script: https://github.com/mozilla/community-tc-config/blob/d89a764692a483c0ae91326e89af5026b2a2d965/imagesets/generic-worker-ubuntu-18-04-staging/bootstrap.sh
 relman-win2012r2:
   workerImplementation: generic-worker
   aws:

--- a/imagesets/docker/Dockerfile
+++ b/imagesets/docker/Dockerfile
@@ -1,22 +1,17 @@
 FROM ubuntu:20.04
 
-COPY signin-aws /usr/bin/signin-aws
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y git pass curl unzip jq yubioath-desktop && \
-    curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
+    curl -L https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
     unzip awscliv2.zip && \
     aws/install && \
     apt-get install -y software-properties-common && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64 && \
-    add-apt-repository ppa:rmescandon/yq && \
-    apt update -y && \
-    apt install -y yq && \
+    curl -L https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && \
+    chmod a+x /usr/local/bin/yq && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    curl -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt-get update -y && \
-    apt-get install -y google-cloud-sdk && \
-    chmod a+x /usr/bin/signin-aws
+    apt-get install -y google-cloud-sdk

--- a/imagesets/docker/TAG
+++ b/imagesets/docker/TAG
@@ -1,1 +1,1 @@
-taskcluster/imageset:1.1
+taskcluster/imageset:1.2


### PR DESCRIPTION
This is a bit of a cleanup for the issues we discovered today. It does the following:

1) `signin-aws` is now not a system dependency, but is included in the repository. It has been renamed to `signin-aws.sh` to make it clearer that it is just a shell script. Also the name doesn't overload the function name that can be used to source it from the shell, to make it a little more obvious that the function and the executable script are different things.

The idea is that if you source its output, it sets env vars for you for 6 hours, so you don't need to run it every time you build an image set, e.g. you could source its output once to get an AWS session, and then create all image sets, without needing to reauthenticate.

2) The unique ID generation process has changed from using `tr` to using `base64` instead. It achieves a similar goal, in a slightly more portable way - essentially generated a random string of 20 chars including [a-z0-9] chars. Since some filesystems are case insensitive, I went with lowercase a-z only, to keep things simple.

3) I rebuild the docker image and bumped the version. Also explicitly download v3.4.1 of yq instead of latest version in Dockerfile.

4) I removed dependency on grep, since sed is already a dependency, used that instead.

5) Made the detection of exceptions more strict and consistent with

```
set -eu
set -o pipefail
```

I also tried adding `export SHELLOPTS` but this broke the `pass` commands, and then on reflection, I decided it was better not to have it. The alternative would be to add it, and then unexport SHELLOPTS (`export -n SHELLOPTS`) prior to any `pass` commands (and `export` it again after each `pass` command) - but that felt a bit overkill. Another option would be to fix the environment so that `SHELLOPTS` could be exported (e.g. `PASSWORD_STORE_GPG_OPTS= pass ...`) but then it becomes very sensitive to `pass` changes, so on reflection I decided better not to try to be too clever.

It is possible that this might introduce a failure where we didn't have one before, but since we are going to be testing rollout of AWS and Google images, hopefully we'll catch anything that this might have broken (e.g. due to an environment variable being evaluated that hasn't been initialised). Also I'm currently testing a deployment of `generic-worker-ubuntu-18-04-staging` into AWS to see if all is ok.

6) More consistent syntax (e.g. `${var}` rather than `$var`) when I saw inconsistencies.