### PR TITLE
Push generated git commits to community-tc-config repo

### DIFF
--- a/imagesets/signin-aws.sh
+++ b/imagesets/signin-aws.sh
@@ -59,7 +59,7 @@ if [ -z "${SERIAL_NUMBER}" ]; then
   exit 64
 fi
 
-aws sts get-session-token --serial-number  "${SERIAL_NUMBER}" --token-code "${TOKEN}" --duration-seconds "${DURATION}" --query 'Credentials.{A:AccessKeyId,B:SecretAccessKey,C:SessionToken}' --output text | while read AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
+aws sts get-session-token --serial-number "${SERIAL_NUMBER}" --token-code "${TOKEN}" --duration-seconds "${DURATION}" --query 'Credentials.{A:AccessKeyId,B:SecretAccessKey,C:SessionToken}' --output text | while read AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
   # Print result as importable for eval
   echo "export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'"
   echo "export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'"


### PR DESCRIPTION
A few cleanup items here:

1) The generated commit added to the community-tc-config repo when `imageset.sh` is run, is now automatically pushed to github
2) Additional checks when running `imageset.sh` that:
  a) no local (uncommitted) changes exist
  b) local HEAD commit matches remote `main` branch of mozilla/community-tc-config github repo
3) Exit code cleanup - exit code 65 was used in two places, so renumbered all the exit codes (nothing currently using them, so should be safe to change them)

I can't properly test these changes until they land, since one of the changes is to ensure that current HEAD matches remote `main` branch, and that will fail while these commits haven't made it to the `main` branch. In any case, I'll comment those lines out and check the new git pull/push commands.