### PR TITLE
Some fix-ups to imageset.sh

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -5,9 +5,9 @@ set -o pipefail
 
 function log {
   if [ -n "${BACKGROUND_COLOUR-}" ] && [ -n "${FOREGROUND_COLOUR-}" ] && [ -n "${CLOUD-}" ] && [ -n "${IMAGE_SET-}" ] && [ -n "${REGION-}" ]; then
-    echo -e "\x1B[48;5;${BACKGROUND_COLOUR}m\x1B[38;5;${FOREGROUND_COLOUR}m$(basename "${0}"): $(date): ${CLOUD}: ${IMAGE_SET}: ${REGION}: ${@}\x1B[0m"
+    echo -e "\x1B[48;5;${BACKGROUND_COLOUR}m\x1B[38;5;${FOREGROUND_COLOUR}m$(basename "${0}"): $(date): ${CLOUD}: ${IMAGE_SET}: ${REGION}: ${@}\x1B[K\x1B[0m"
   else
-    echo -e "\x1B[48;5;123m\x1B[38;5;0m$(basename "${0}"): $(date): ${@}\x1B[0m"
+    echo -e "\x1B[48;5;123m\x1B[38;5;0m$(basename "${0}"): $(date): ${@}\x1B[K\x1B[0m"
   fi
 }
 
@@ -32,8 +32,8 @@ function deploy {
     log "${0} requires yq version 3 in your PATH, but you have:" >&2
     log "    $(which yq)" >&2
     log "    $(yq --version 2>&1)" >&2
-    log "See https://mikefarah.gitbook.io/yq/upgrading-from-v3 about backward incompatibility of version 4 and higher."
-    log "Note, an alternative solution is to upgrade this script to use v4 syntax and rebuild/publish docker container etc."
+    log "See https://mikefarah.gitbook.io/yq/upgrading-from-v3 about backward incompatibility of version 4 and higher." >&2
+    log "Note, an alternative solution is to upgrade this script to use v4 syntax and rebuild/publish docker container etc." >&2
     exit 65
   else
     log "  \xE2\x9C\x94 yq is version 3"
@@ -87,6 +87,23 @@ function deploy {
     exit 70
   fi
 
+  if [ "${CLOUD}" == "google" ] && [ -z "${GCP_PROJECT-}" ]; then
+    log "Environment variable GCP_PROJECT must be exported before calling this script" >&2
+    exit 71
+  fi
+
+  if ! [ -d "${IMAGE_SET}" ]; then
+    log "Directory $(pwd)/${IMAGE_SET} not found - please specify a valid directory for image set" >&2
+    exit 72
+  fi
+
+  echo test | pass insert -m -f "test"
+  if [ "$(pass test)" != "test" ]; then
+    log "Problem writing to password store" >&2
+    exit 73
+  fi
+  pass git reset --hard HEAD~1 >/dev/null 2>&1
+
   log 'Starting!'
 
   export IMAGE_SET_COMMIT_SHA="$(git rev-parse HEAD)"
@@ -123,10 +140,6 @@ function deploy {
       pass git push
       ;;
     google)
-      if [ -z "${GCP_PROJECT-}" ]; then
-        log "Environment variable GCP_PROJECT must be exported before calling this script" >&2
-        exit 71
-      fi
       echo us-central1-a 21 230 | xargs -P1 -n3 "./$(basename "${0}")" process-region "${CLOUD}_${ACTION}"
       log "Updating config/imagesets.yml..."
       IMAGE_NAME="$(cat "${IMAGE_SET}/gcp.secrets")"


### PR DESCRIPTION
The `imageset.sh` script builds machine images (expensive, time-consuming) and then updates password store with credentials to connect to new machine images. However, if there is a problem with the password store / gpg setup of the user running `imageset.sh`, they will only discover this after the new machine images have been built.

I added a pre-check that writing secrets to the password store works, before beginning the long process of generating machine images, to reduce chance of failure once the image building process has started.

At the same time, I modified the log routine to clear to end-of-line on line return, so that the background colour extends to the full terminal width on line returns (aesthetic improvement).

I also moved all checks to before the 'Starting!' log line and added a check that the specified imageset directory exists.

Note:

One thing I don't love about the new password store test, is that if for some reason the test secret insertion is successful, but the test secret removal isn't successful, there is a risk that we get a secret `test` added to the password store.

However, I think the risk outweighs the benefit. I'm not sure of the best way to guard against this. Rerunning the script would fetch a new clone of the repo, so the only way this could be a problem is if the removal of the secret silently failed, and then the script continued to build images and push changes to the git repo. This seems like a very small risk, as the secret removal silently failing would indicate a bug in pass or git (`pass git reset --hard HEAD~1`) since the pass command should have a non-zero exit command if the command fails. Also since it doesn't interact with the network, there is low chance it should fail. It is also a dedicated checkout of the password store for the current process, rather than a system-wide password store checkout, so there shouldn't be any race conditions which could cause the wrong commit to be removed etc.