### PR TITLE
Only run AWS steps when in AWS

### DIFF
--- a/imagesets/generic-worker-win2012r2/bootstrap.ps1
+++ b/imagesets/generic-worker-win2012r2/bootstrap.ps1
@@ -189,11 +189,13 @@ Expand-ZIPFile -File "C:\ProcessMonitor.zip" -Destination "C:\ProcessMonitor" -U
 
 # See https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html#ec2launch-inittasks
 # schedule one time run of EC2Launch service on first boot of instances to ensure network routes are correctly configured
-C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
-# make sure admin password isn't changed, since we've already captured the current random password
-$launchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' -raw | ConvertFrom-Json
-$launchConfig.adminPasswordType = "DoNothing"
-$launchConfig | ConvertTo-Json -depth 32 | Set-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json'
+if ("%MY_CLOUD%" -eq "aws") {
+  C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
+  # make sure admin password isn't changed, since we've already captured the current random password
+  $launchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' -raw | ConvertFrom-Json
+  $launchConfig.adminPasswordType = "DoNothing"
+  $launchConfig | ConvertTo-Json -depth 32 | Set-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json'
+}
 
 # now shutdown, in preparation for creating an image
 # Stop-Computer isn't working, also not when specifying -AsJob, so reverting to using `shutdown` command instead

--- a/imagesets/generic-worker-win2016/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016/bootstrap.ps1
@@ -189,11 +189,13 @@ Expand-ZIPFile -File "C:\ProcessMonitor.zip" -Destination "C:\ProcessMonitor" -U
 
 # See https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html#ec2launch-inittasks
 # schedule one time run of EC2Launch service on first boot of instances to ensure network routes are correctly configured
-C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
-# make sure admin password isn't changed, since we've already captured the current random password
-$launchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' -raw | ConvertFrom-Json
-$launchConfig.adminPasswordType = "DoNothing"
-$launchConfig | ConvertTo-Json -depth 32 | Set-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json'
+if ("%MY_CLOUD%" -eq "aws") {
+  C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
+  # make sure admin password isn't changed, since we've already captured the current random password
+  $launchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' -raw | ConvertFrom-Json
+  $launchConfig.adminPasswordType = "DoNothing"
+  $launchConfig | ConvertTo-Json -depth 32 | Set-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json'
+}
 
 # now shutdown, in preparation for creating an image
 # Stop-Computer isn't working, also not when specifying -AsJob, so reverting to using `shutdown` command instead


### PR DESCRIPTION
No need to try to run this step when deploying in a different cloud (like google cloud).

The powershell previously would fail silently, but let's not even try to run it if we are in the wrong cloud, and this serves as a reminder to editors of the bootstrap script, that the scripts may need to work in multiple cloud environments.