### PR TITLE
Stop running jcristau-fx-release-metrics daily

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -28,7 +28,6 @@ misc:
       description: Taskcluster hook to run fx release metrics
       owner: jcristau@mozilla.com
       emailOnError: true
-      schedule: ['0 0 8 * * *']
       task:
         provisionerId: proj-misc
         workerType: ci


### PR DESCRIPTION
I'm not using it at the moment, and it has recently been failing.