### PR TITLE
Remove push command prefix and update assume:hook-id

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -208,13 +208,12 @@ mozci:
           env:
             TASKCLUSTER_SECRET: project/mozci/testing
           command:
-            - push
             - check-backfills
             - --nb-pushes=20
             - --environment=testing
           maxRunTime: 1800
         scopes:
-          - assume:hook-id:project-mozci/monitoring-testing
+          - assume:hook-id:project-mozci/check-backfills-testing
         metadata:
           name: mozci check-backfills - testing
           description: Check backfill completion every few minutes
@@ -301,12 +300,11 @@ mozci:
           env:
             TASKCLUSTER_SECRET: project/mozci/production
           command:
-            - push
             - check-backfills
             - --environment=production
           maxRunTime: 1800
         scopes:
-          - assume:hook-id:project-mozci/monitoring-production
+          - assume:hook-id:project-mozci/check-backfills-production
         metadata:
           name: mozci check-backfills - production
           description: Check backfill completion every few minutes


### PR DESCRIPTION
After a discussion with @marco-c we decided to remove the `push` command prefix from the command of the new mozci hook.

There is also a typo in the scopes declaration of both testing & production hooks: the `assume:hook-id` is not the correct one.

We currently have the following error which should be fixed by this PR:

```
The error was:
Error: Client ID static/taskcluster/hooks does not have sufficient scopes and is missing the following scopes:

assume:hook-id:project-mozci/monitoring-testing
This request requires the client to satisfy the following scope expression:

{
  "AllOf": [
    "assume:hook-id:project-mozci/monitoring-testing",
    "queue:create-task:project:none",
    "queue:scheduler-id:-",
    {
      "AnyOf": [
        "queue:create-task:highest:proj-mozci/compute-smaller",
        "queue:create-task:very-high:proj-mozci/compute-smaller",
        "queue:create-task:high:proj-mozci/compute-smaller",
        "queue:create-task:medium:proj-mozci/compute-smaller",
        "queue:create-task:low:proj-mozci/compute-smaller",
        "queue:create-task:very-low:proj-mozci/compute-smaller",
        "queue:create-task:lowest:proj-mozci/compute-smaller"
      ]
    }
  ]
}
```