### PR TITLE
Update base GCP image for generic-worker-win2012r2-staging

### DIFF
--- a/imagesets/generic-worker-win2012r2-staging/gcp_filters
+++ b/imagesets/generic-worker-win2012r2-staging/gcp_filters
@@ -1,1 +1,1 @@
---image=windows-server-2012-r2-dc-v20190910 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard
+--image=windows-server-2012-r2-dc-v20191008 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard

--- a/imagesets/generic-worker-win2012r2/gcp_filters
+++ b/imagesets/generic-worker-win2012r2/gcp_filters
@@ -1,1 +1,1 @@
---image=windows-server-2012-r2-dc-v20190910 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard
+--image=windows-server-2012-r2-dc-v20191008 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard

--- a/imagesets/relman-win2012r2/gcp_filters
+++ b/imagesets/relman-win2012r2/gcp_filters
@@ -1,1 +1,1 @@
---image=windows-server-2012-r2-dc-v20190910 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard
+--image=windows-server-2012-r2-dc-v20191008 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard


### PR DESCRIPTION
Got a warning when building, that the image was deprecated, and that I should use this new one.