### PR TITLE
Move gw-ubuntu-20-04-staging from gcp to aws

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -139,7 +139,7 @@ taskcluster:
       owner: pmoore@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-20-04-staging
-      cloud: gcp
+      cloud: aws
       minCapacity: 0
       maxCapacity: 10
 


### PR DESCRIPTION
In GCP we are getting error "No user logged in with console session" so moving to AWS.