### PR TITLE
Add missing metadata description

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -615,6 +615,7 @@ fuzzing:
           name: covdiff
           owner: jkratzer@mozilla.com
           source: https://github.com/MozillaSecurity/covdiff
+          description: Hook for downloading, merging, and submitting Mozilla CI coverage reports
         workerType: ci
         provisionerId: proj-fuzzing
       schedule:


### PR DESCRIPTION
Looks like I removed the required `description` parameter from `metadata`.  Without it, this hook cannot be triggered.