### PR TITLE
Allow to re-run failed tasks from github

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -243,6 +243,7 @@ taskcluster:
         - queue:create-artifact:*
         - queue:create-task:lowest:null-provisioner/*
         - queue:create-task:lowest:proj-taskcluster/ci
+        - queue:rerun-task:taskcluster-level-1/*
         - queue:get-artifact:private/docker-worker-tests/*
         - queue:resolve-task
         - queue:route:statuses


### PR DESCRIPTION
Currently when we click "re-run" on a failed builds we get an error:

```
Client ID static/taskcluster/github does not have sufficient scopes and is missing the following scopes:

{
  "AnyOf": [
    "queue:rerun-task:taskcluster-level-1/f0VYFxm8Q9SBeIpBWqCK1Q/GXJkIXslRVSrJ77GrfEYoA",
    "queue:rerun-task-in-project:none",
    {
      "AllOf": [
        "queue:rerun-task",
        "assume:scheduler-id:taskcluster-level-1/f0VYFxm8Q9SBeIpBWqCK1Q"
      ]
    }
  ]
}
```