### PR TITLE
Use GPU instances for Grizzly reducer Windows pool.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -63,10 +63,12 @@ fuzzing:
     grizzly-reduce-worker-windows:
       owner: truber@mozilla.com
       emailOnError: true
-      imageset: generic-worker-win2016
+      imageset: generic-worker-win2016-amd
       cloud: aws
       minCapacity: 0
       maxCapacity: 10
+      instanceTypes:
+        g4ad.2xlarge: 1
   hooks:
     fuzzing-tc-config-community-update:
       description: Run Fuzzing pool rebuild when Community-TC config changes


### PR DESCRIPTION
We're seeing many task failures since enabling fuzzing on GPU instances because we later try to reduce those crashes on non-GPU instances.