### PR TITLE
Add disableSeccomp scope to docker-worker-tester

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -228,10 +228,12 @@ taskcluster:
         - docker-worker:capability:device:loopbackAudio
         - docker-worker:capability:device:loopbackVideo
         - docker-worker:capability:device:hostSharedMemory
+        - docker-worker:capability:disableSeccomp
         - docker-worker:capability:privileged
         - docker-worker:capability:device:loopbackAudio:null-provisioner/*
         - docker-worker:capability:device:loopbackVideo:null-provisioner/*
         - docker-worker:capability:device:hostSharedMemory:null-provisioner/*
+        - docker-worker:capability:disableSeccomp:null-provisioner/*
         - docker-worker:capability:privileged:null-provisioner/*
         - docker-worker:image:localhost:*
         - purge-cache:null-provisioner/*


### PR DESCRIPTION
I believe this is what's required for the docker-worker tests run in https://github.com/taskcluster/taskcluster/pull/5695