### PR TITLE
build(AMI): update docker worker AMIs on AWS (for #516)

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -52,12 +52,12 @@ docker-worker:
   gcp:
     image: projects/taskcluster-imaging/global/images/docker-worker-5nrfllxteqxz1yrln5kx
   aws:
-    # originally built with the `docker_worker_community_aws` builder in monopacker
+    # originally built with the `docker_community_aws` builder in monopacker
     amis:
-      us-east-1: ami-0bd18568d25fa4852
-      us-west-1: ami-0128d94ca859fcd2b
-      us-west-2: ami-0123f65a860be84bb
-      us-east-2: ami-07b28b1eb79e1dd6f
+      us-east-1: ami-0b4d9c5abc0f492bd
+      us-east-2: ami-0e2c20208b702d6e8
+      us-west-1: ami-0d0bfb7c04e580cb4
+      us-west-2: ami-00f9e48a414768c43
 generic-worker-win2012r2:
   workerImplementation: generic-worker
   aws:


### PR DESCRIPTION
Fixes #516.

Built using [monopacker](https://github.com/taskcluster/monopacker/tree/matt-boris/updateDockerWorker).