### PR TITLE
Fix docker-worker config for disableSeccomp feature in proj-taskcluster/dw-ci worker pool

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -52,7 +52,7 @@ taskcluster:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
-          disableSeccomp: true
+          allowDisableSeccomp: true
 
     windows2012r2-amd64-ci:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
The docker-worker _config setting_ to say whether the worker accepts tasks that use the `disableSeccomp` feature is `allowDisableSeccomp`.