### PR TITLE
Move bugmon-processor to gcp and bugmon-pernosco to aws

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -19,19 +19,18 @@ fuzzing:
       owner: jkratzer@mozilla.com
       emailOnError: false
       imageset: docker-worker-2022
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
       workerConfig:
         dockerConfig:
           allowPrivileged: true
           allowDisableSeccomp: true
-      securityGroup: docker-worker
     bugmon-pernosco:
       owner: jkratzer@mozilla.com
       emailOnError: false
       imageset: docker-worker-2022
-      cloud: gcp
+      cloud: aws
       minCapacity: 0
       maxCapacity: 10
       instanceTypes:
@@ -40,6 +39,7 @@ fuzzing:
         dockerConfig:
           allowPrivileged: true
           allowDisableSeccomp: true
+      securityGroup: docker-worker
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false


### PR DESCRIPTION
Although the audio/video issues have not been resolved on aws, the `bugmon-pernosco` pool must use aws (due to the bare-metal requirement).  This pool will not actually be enabled via the hook until the audio/video issues have been resolved.

Additionally, the `bugmon-processor` pool should use gcp.