### PR TITLE
Add a role for testing #5777

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -327,6 +327,18 @@ taskcluster:
         - repo:github.com/taskcluster/docker-exec-websocket-server:*
         - repo:github.com/taskcluster/docker-exec-websocket-client:*
 
+    # temporary scopes to allow dustin to test #5777
+    - grant:
+        # create tasks for proj-taskcluster/dustin-testing-5777 with projectId dustin-testing-5777
+        - queue:create-task:project:dustin-testing-5777
+        - queue:create-task:highest:proj-taskcluster/dustin-testing-5777
+        - queue:scheduler-id:dustin-testing-5777
+        # manage the static worker pool proj-taskcluster/dustin-testing-5777
+        - worker-manager:manage-worker-pool:proj-taskcluster/dustin-testing-5777
+        - worker-manager:provider:static
+      to:
+        - login-identity:github/28673|djmitche
+
   clients:
     smoketests:
       scopes:


### PR DESCRIPTION
This should allow me to
 * create tasks in a test task queue, for a specific projectId
 * create a worker polling that task queue

Depending on the configuration of the object service, this may or may not be able to create objects -- we'll see!