### PR TITLE
Add allowDisableSeccomp to bugmon-monitor

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -15,6 +15,7 @@ fuzzing:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
+          allowDisableSeccomp: true
     bugmon-processor:
       owner: jkratzer@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This is required for running pernosco-submit on the bugmon reporter instances.