### PR TITLE
chore(cleanup): remove stale `disableSeccomp` config

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -25,7 +25,6 @@ fuzzing:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
-          allowDisableSeccomp: true
     bugmon-pernosco:
       owner: jkratzer@mozilla.com
       emailOnError: false
@@ -38,7 +37,6 @@ fuzzing:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
-          allowDisableSeccomp: true
       securityGroup: docker-worker
     ci:
       owner: fuzzing+taskcluster@mozilla.com

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -52,7 +52,6 @@ taskcluster:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
-          allowDisableSeccomp: true
 
     windows2012r2-amd64-ci:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
Since https://github.com/taskcluster/taskcluster/pull/5800/files#diff-efc540af1977441446fbe043646cb2d22ee386c0a5d50a4d0ebafc1312ba061fL51-L54, this config is no longer used/needed.