### PR TITLE
fix(tc release): fix tc release worker pool to run tasks as current user (root)

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -47,6 +47,10 @@ taskcluster:
       cloud: aws
       minCapacity: 0
       maxCapacity: 1
+      workerConfig:
+        genericWorker:
+          config:
+            runTasksAsCurrentUser: true
 
     dw-ci:
       # docker-worker's CI requires the 'privileged' scope, so run


### PR DESCRIPTION
This was accidentally reverted in https://github.com/mozilla/community-tc-config/pull/535.