### PR TITLE
Add AMD drivers to the Windows 2022 imageset

### DIFF
--- a/imagesets/generic-worker-win2022/aws_instance_profile
+++ b/imagesets/generic-worker-win2022/aws_instance_profile
@@ -1,0 +1,1 @@
+AMDDriverS3Access


### PR DESCRIPTION
We're already using the new Windows 2022 images for non-GPU instances. I believe this is all that's required to add the drivers to the imageset.