### PR TITLE
Create legacy docker worker imageset based on v44.23.4 for disableSeccomp feature

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -58,6 +58,18 @@ docker-worker:
       us-east-2: ami-0a172d261610275a8
       us-west-1: ami-079635988fff55b09
       us-west-2: ami-08c278b93b0349b65
+# v44.23.4 docker worker which includes the disableSeccomp feature
+docker-worker-legacy:
+  workerImplementation: docker-worker
+  gcp:
+    image: projects/taskcluster-imaging/global/images/docker-community-gcp-googlecompute-2022-12-19t19-01-04z
+  aws:
+    # originally built with the `docker_community_aws` builder in monopacker
+    amis:
+      us-east-1: ami-0ec6d5fc54628fa9b
+      us-east-2: ami-071b3ff08f2d9c1dd
+      us-west-1: ami-03f677a21b2fadb15
+      us-west-2: ami-0de87470eb34a8e36
 relman-win2012r2:
   workerImplementation: generic-worker
   aws:


### PR DESCRIPTION
This creates a new imageset based off of v44.23.4 to include the `disableSeccomp` feature.

cc: @jschwartzentruber @pyoor