### PR TITLE
New roles would be assumed for releases

### DIFF
--- a/config/projects/firefoxreality.yml
+++ b/config/projects/firefoxreality.yml
@@ -53,6 +53,7 @@ firefoxreality:
         - secrets:get:project/firefoxreality/fr/release-signing-token
       to:
         - repo:github.com/MozillaReality/FirefoxReality:release
+        - repo:github.com/MozillaReality/FirefoxReality:release:*
     - grant:
         - queue:route:index.project.firefoxreality.*
       to:

--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -47,5 +47,6 @@ git-cinnabar:
         - queue:route:index.project.git-cinnabar.*
       to:
         - repo:github.com/glandium/git-cinnabar:release
+        - repo:github.com/glandium/git-cinnabar:release:*
         - repo:github.com/glandium/git-cinnabar:branch:*
         - repo:github.com/glandium/git-cinnabar:tag:*


### PR DESCRIPTION
Due to the changes in github service of Taskcluster, we need to adjust few roles here.

There are just two projects who defined separate `:release` roles, so in order to keep it working we'd need to merge this one right after we make a release to community.

Please see https://github.com/taskcluster/taskcluster/pull/5940