### PR TITLE
Enable sshd on proj-taskcluster windows workers

### DIFF
--- a/config/aws.yml
+++ b/config/aws.yml
@@ -47,18 +47,22 @@ security_groups:
     no-inbound: sg-00c4014bc978171d5
     docker-worker: sg-0d2ff88f36a05b499
     rdp: sg-0ddc5eae2e56a43c5
+    ssh: sg-0f9ee22a4a6cef474
 
   us-west-2:
     no-inbound: sg-0659c2937ecbe7254
     docker-worker: sg-0f8a656368c567425
     rdp: sg-0728e02d721b9d2c8
+    ssh: sg-0985b20410d30c5b2
 
   us-east-1:
     no-inbound: sg-07f7d21a488e192c6
     docker-worker: sg-08fea1235cf66b102
     rdp: sg-0f814fceb57681f0b
+    ssh: sg-04e801d56ce1f8d85
 
   us-east-2:
     no-inbound: sg-00a9d64b3595c5088
     docker-worker: sg-0388de36e2f30ced2
     rdp: sg-0ba932a63b653dc19
+    ssh: sg-009999abb8ebe2627

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -40,7 +40,8 @@ fuzzing:
         dockerConfig:
           allowPrivileged: true
           allowDisableSeccomp: true
-      securityGroup: docker-worker
+      securityGroups:
+        - docker-worker
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -44,7 +44,8 @@ relman:
       emailOnError: false
       imageset: relman-win2012r2
       cloud: aws
-      securityGroup: rdp
+      securityGroups:
+        - rdp
       minCapacity: 0
       maxCapacity: 10
   secrets:

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -25,7 +25,8 @@ taskcluster:
       description: not actively used, but useful for testing docker-worker on AWS
       emailOnError: false
       imageset: docker-worker
-      securityGroup: docker-worker
+      securityGroups:
+        - docker-worker
       cloud: aws
       minCapacity: 0
       maxCapacity: 1
@@ -98,7 +99,8 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-win2022
       cloud: aws
-      securityGroup: rdp
+      securityGroups:
+        - rdp
       minCapacity: 0
       maxCapacity: 10
       workerConfig:
@@ -133,7 +135,8 @@ taskcluster:
       emailOnError: true
       imageset: generic-worker-win2022
       cloud: aws
-      securityGroup: rdp
+      securityGroups:
+        - rdp
       minCapacity: 0
       maxCapacity: 10
 

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -101,6 +101,7 @@ taskcluster:
       cloud: aws
       securityGroups:
         - rdp
+        - ssh
       minCapacity: 0
       maxCapacity: 10
       workerConfig:
@@ -137,6 +138,7 @@ taskcluster:
       cloud: aws
       securityGroups:
         - rdp
+        - ssh
       minCapacity: 0
       maxCapacity: 10
 

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -373,7 +373,7 @@ def aws(
         "m4.2xlarge": 1,
         "m5.2xlarge": 1,
     },
-    securityGroup="no-inbound",
+    securityGroups=["no-inbound"],
     minCapacity=0,
     maxCapacity=None,
     **cfg,
@@ -385,7 +385,7 @@ def aws(
       regions: regions to deploy to (required)
       instanceTypes: dict of instance types to provision, values are
                      capacityPerInstance (required)
-      securityGroup: name of the security group to apply (default no-inbound)
+      securityGroups: list of the security groups to apply (default ["no-inbound"])
       minCapacity: minimum capacity to run at any time (default 0)
       maxCapacity: maximum capacity to run at any time (required)
     """
@@ -412,7 +412,9 @@ def aws(
 
     launchConfigs = []
     for region in regions:
-        groupId = aws_config["security_groups"][region][securityGroup]
+        groupIds = [
+            aws_config["security_groups"][region][group] for group in securityGroups
+        ]
         for az, subnetId in aws_config["subnets"][region].items():
             for instanceType, capacityPerInstance in instanceTypes.items():
                 # Filter out availability zones where the required instance type
@@ -426,7 +428,7 @@ def aws(
                         "ImageId": imageIds[region],
                         "Placement": {"AvailabilityZone": az},
                         "SubnetId": subnetId,
-                        "SecurityGroupIds": [groupId],
+                        "SecurityGroupIds": groupIds,
                         "InstanceType": instanceType,
                         "InstanceMarketOptions": {"MarketType": "spot"},
                     },

--- a/imagesets/generic-worker-win2016-amd/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016-amd/bootstrap.ps1
@@ -167,7 +167,7 @@ $env:LOGONSERVER = "\\" + $env:COMPUTERNAME
 Start-Process "C:\cygwin\bin\bash.exe" -ArgumentList "--login -c `"ssh-host-config -y -c 'ntsec mintty' -u 'cygwinsshd' -w 'qwe123QWE!@#'`"" -Wait -NoNewWindow -PassThru
 
 # start sshd
-Start-Process "net" -ArgumentList "start sshd" -Wait -NoNewWindow -PassThru
+Start-Process "net" -ArgumentList "start cygsshd" -Wait -NoNewWindow -PassThru
 
 # download bash setup script
 $client.DownloadFile("https://raw.githubusercontent.com/petemoore/myscrapbook/master/setup.sh", "C:\cygwin\home\Administrator\setup.sh")

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -167,7 +167,7 @@ $env:LOGONSERVER = "\\" + $env:COMPUTERNAME
 Start-Process "C:\cygwin\bin\bash.exe" -ArgumentList "--login -c `"ssh-host-config -y -c 'ntsec mintty' -u 'cygwinsshd' -w 'qwe123QWE!@#'`"" -Wait -NoNewWindow -PassThru
 
 # start sshd
-Start-Process "net" -ArgumentList "start sshd" -Wait -NoNewWindow -PassThru
+Start-Process "net" -ArgumentList "start cygsshd" -Wait -NoNewWindow -PassThru
 
 # download bash setup script
 $client.DownloadFile("https://raw.githubusercontent.com/petemoore/myscrapbook/master/setup.sh", "C:\cygwin\home\Administrator\setup.sh")


### PR DESCRIPTION
It might be easiest to review the commits in sequence. This PR fixes the installation of an ssh daemon on the Windows workers (for everyone) but only applies the ssh security group to the proj-taskcluster Windows workers running in AWS. This should make it possible to ssh onto Windows workers when there are problems. It was already possible to RDP onto them.

Note, this required a fix to the python code to allow workers to be in more than one security group.

Thanks!