### PR TITLE
Bump tc version to latest and update passwordstore location

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_REF='v46.0.0'
+TASKCLUSTER_REF='v47.0.3'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v46.0.0'
+TASKCLUSTER_VERSION='v47.0.3'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v46.0.0"
+$TASKCLUSTER_VERSION = "v47.0.3"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -105,7 +105,17 @@ function deploy {
 
   export TEMP_DIR="$(mktemp -d -t password-store.XXXXXXXXXX)"
   export PASSWORD_STORE_DIR="${TEMP_DIR}/.password-store"
-  git clone ssh://gitolite3@git-internal.mozilla.org/taskcluster/secrets.git "${PASSWORD_STORE_DIR}"
+  # Register your ssh public key with https://source.cloud.google.com/user/ssh_keys?register=true
+  #
+  # Add the following to your ~/.ssh/config:
+  #
+  # Host source.developers.google.com
+  #  User <user>@mozilla.com
+  #  UpdateHostKeys yes
+  #  IdentityFile <path to your private key>
+  #  Port 2022
+  #
+  git clone ssh://source.developers.google.com/p/taskcluster-passwords/r/secrets "${PASSWORD_STORE_DIR}"
   git -C "${PASSWORD_STORE_DIR}" config pass.signcommits false
   git -C "${PASSWORD_STORE_DIR}" config commit.gpgsign false
 

--- a/imagesets/relman-win2012r2/bootstrap.ps1
+++ b/imagesets/relman-win2012r2/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v46.0.0"
+$TASKCLUSTER_VERSION = "v47.0.3"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
~~`gcc` appears to be required to fix the CI failure from https://github.com/taskcluster/taskcluster/pull/6050.~~
From https://go.dev/doc/go1.20:
>On Linux and other Unix systems, and on Windows, a host C toolchain is required to use the race detector.

Edit: I'll try to fix this in a later PR.

This change also clones the passwordstore from its new repo. Please follow these instructions to get it to work for you @petemoore and @lotas (@hwine too if you'd like to set it up).
```bash
  # Register your ssh public key with https://source.cloud.google.com/user/ssh_keys?register=true
  #
  # Add the following to your ~/.ssh/config:
  #
  # Host source.developers.google.com
  #  User <user>@mozilla.com
  #  UpdateHostKeys yes
  #  IdentityFile <path to your private key>
  #  Port 2022
  #
```

View updated readme [here](https://source.cloud.google.com/taskcluster-passwords/secrets).