### PR TITLE
chore: bump tc to v49.0.0

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_REF='v48.2.0'
+TASKCLUSTER_REF='v49.0.0'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v48.2.0'
+TASKCLUSTER_VERSION='v49.0.0'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v48.2.0"
+$TASKCLUSTER_VERSION = "v49.0.0"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/imagesets/relman-win2012r2/bootstrap.ps1
+++ b/imagesets/relman-win2012r2/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v48.2.0"
+$TASKCLUSTER_VERSION = "v49.0.0"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
https://taskcluster.github.io/changelog-viewer/#releaseFrom=v48.2.0&releaseTo=v49.0.0