### PR TITLE
Update all worker pools to generic-worker 49.1.2

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_REF='v49.1.1'
+TASKCLUSTER_REF='v49.1.2'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v49.1.1'
+TASKCLUSTER_VERSION='v49.1.2'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2016-amd/bootstrap.ps1
+++ b/imagesets/generic-worker-win2016-amd/bootstrap.ps1
@@ -1,3 +1,10 @@
+# This script is not maintained!!
+#
+# See https://github.com/mozilla/community-tc-config/pull/549#issuecomment-1353426207
+# This is just a working version used by the fuzzing team, until they are able
+# to migrate to the standard Windows Server image set that we provide.
+#
+# Do not update unless necessary!
 $TASKCLUSTER_VERSION = "44.21.0"
 
 # use TLS 1.2 (see bug 1443595)

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v49.1.1"
+$TASKCLUSTER_VERSION = "v49.1.2"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/imagesets/relman-win2012r2/bootstrap.ps1
+++ b/imagesets/relman-win2012r2/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v49.1.1"
+$TASKCLUSTER_VERSION = "v49.1.2"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
This is useful for testing https://bugzilla.mozilla.org/show_bug.cgi?id=1815711 on Windows, and keeps everything else up-to-date at the same time.