### PR TITLE
Disable AV and disk indexing in Windows images for improved performance

### DIFF
--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -24,6 +24,12 @@ function Expand-ZIPFile($file, $destination, $url)
 # allow powershell scripts to run
 Set-ExecutionPolicy Unrestricted -Force -Scope Process
 
+# Disable AV for IO speed
+Set-Service "WinDefend" -StartupType Disabled -Status Stopped
+
+# Disable disk indexing
+Set-Service "WSearch" -StartupType Disabled -Status Stopped
+
 # install chocolatey package manager
 Invoke-Expression ($client.DownloadString('https://chocolatey.org/install.ps1'))
 

--- a/imagesets/relman-win2012r2/bootstrap.ps1
+++ b/imagesets/relman-win2012r2/bootstrap.ps1
@@ -24,6 +24,12 @@ function Expand-ZIPFile($file, $destination, $url)
 # allow powershell scripts to run
 Set-ExecutionPolicy Unrestricted -Force -Scope Process
 
+# Disable AV for IO speed
+Set-Service "WinDefend" -StartupType Disabled -Status Stopped
+
+# Disable disk indexing
+Set-Service "WSearch" -StartupType Disabled -Status Stopped
+
 # install chocolatey package manager
 Invoke-Expression ($client.DownloadString('https://chocolatey.org/install.ps1'))
 


### PR DESCRIPTION
I think this is valuable in general, so applying to both the generic image and the relman specific one.