### PR TITLE
Migrate relman machine image from Windows Server 2012 R2 to Windows Server 2022

### DIFF
--- a/imagesets/relman-win2012r2/aws_filters
+++ b/imagesets/relman-win2012r2/aws_filters
@@ -1,2 +1,2 @@
 Name=platform,Values=windows
-Name=name,Values=Windows_Server-2012-R2_RTM-English-64Bit-Base*
+Name=name,Values=Windows_Server-2022-English-Full-Base-*

--- a/imagesets/relman-win2012r2/gcp_filters
+++ b/imagesets/relman-win2012r2/gcp_filters
@@ -1,1 +1,0 @@
---image=windows-server-2012-r2-dc-v20191008 --image-project=windows-cloud --boot-disk-size=50GB --boot-disk-type=pd-standard


### PR DESCRIPTION
Note, if this works, and fixes the issue, we should rename the image set directory and the worker pool name to reflect the updated version of Windows. But since this might not work, haven't done that yet (will affect the .taskcluster.yml files that specify the worker pool too).

@marco-c Can you take a look and let me know what you think?