### PR TITLE
Configure locations of livelog and taskcluser-proxy on relman-win2022

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -82,6 +82,8 @@ relman-win2022:
     genericWorker:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         shutdownMachineOnIdle: true
         idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true


### PR DESCRIPTION
This should fix livelog on this imageset.

CC @marco-c 