### PR TITLE
Grant generic-worker-tester scopes for reading/writing to Index

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -280,6 +280,7 @@ taskcluster:
 
     - grant:
         - assume:worker-id:test-worker-group/test-worker-id
+        - assume:worker-pool:test-provisioner/*
         - assume:worker-type:test-provisioner/*
         - auth:create-client:project/taskcluster:generic-worker-tester/TestReclaimCancelledTask
         - auth:create-client:project/taskcluster:generic-worker-tester/TestResolveResolvedTask
@@ -290,15 +291,16 @@ taskcluster:
         - generic-worker:cache:unknown-issuer-app-cache
         - generic-worker:os-group:test-provisioner/*
         - generic-worker:run-as-administrator:test-provisioner/*
+        - index:find-task:garbage.generic-worker-tests.*
+        - index:insert-task:garbage.generic-worker-tests.*
         - queue:cancel-task:test-scheduler/*
-        - assume:worker-pool:test-provisioner/*
         - queue:create-artifact:public/*
         - queue:create-task:highest:test-provisioner/*
-        - queue:scheduler-id:test-scheduler
         - queue:get-artifact:SampleArtifacts/_/X.txt
         - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
         - queue:get-artifact:SampleArtifacts/b/c/d.jpg
         - queue:resolve-task
+        - queue:scheduler-id:test-scheduler
       to: project:taskcluster:generic-worker-tester
 
     - grant:


### PR DESCRIPTION
This aligns with the namespace used by docker-worker tests ([garbage.docker-worker-tests](https://community-tc.services.mozilla.com/tasks/index/garbage.docker-worker-tests)).

This will be used for the tests I am adding to the generic-worker mounts feature for Indexed Artifact content (feature added in https://github.com/taskcluster/taskcluster/pull/6246 and released in [taskcluster v51.0.0](https://github.com/taskcluster/taskcluster/releases/tag/v51.0.0)).

This feature was broken in 51.0.0 and a fix was created in https://github.com/taskcluster/taskcluster/pull/6264 but tests are still required, hence the change to the scopes here, as the first step in creating the new tests.