### PR TITLE
Allow taskcluster CI to use any proj-taskcluster worker pools

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -305,8 +305,7 @@ taskcluster:
 
     - grant:
         - assume:project:taskcluster:generic-worker-tester
-        - queue:create-task:highest:proj-taskcluster/gw-ci-*
-        - queue:create-task:highest:proj-taskcluster/dw-ci
+        - queue:create-task:highest:proj-taskcluster/*
         - generic-worker:cache:generic-worker-checkout
         - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
         - queue:scheduler-id:taskcluster-level-1


### PR DESCRIPTION
We have e.g. two distinct Windows worker pools in proj-taskcluster:

* proj-taskcluster/gw-ci-windows-2022 (privileged - tasks run as LocalSystem)
* proj-taskcluster/gw-windows-2022 (regular - tasks run as regular task users)

The first pool is intended for generic-worker CI, which when testing generic worker, needs to be able to create OS users on the fly.
The second pool is a regular pool, for running tasks as normal.

Both pools should be used by the monorepo CI. For example, testing worker runner on windows does not require extra privileges, but testing generic-worker on windows does.

Rather than maintain a list of specific proj-taskcluster worker pools that are allowed, it seems reasonable to allow the CI to use any of the proj-taskcluster worker pools. This should help reduce burden in future each time proj-taskcluster worker pools are renamed or changed etc.

Also needed for https://github.com/taskcluster/taskcluster/pull/6302.