### PR TITLE
How do you like them apples?

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -285,6 +285,7 @@ taskcluster:
         - auth:create-client:project/taskcluster:generic-worker-tester/TestReclaimCancelledTask
         - auth:create-client:project/taskcluster:generic-worker-tester/TestResolveResolvedTask
         - auth:sentry:generic-worker-tests
+        - generic-worker:cache:apple-cache
         - generic-worker:cache:banana-cache
         - generic-worker:cache:devtools-app
         - generic-worker:cache:test-modifications


### PR DESCRIPTION
In https://github.com/taskcluster/taskcluster/pull/6183 a test was updated, requiring scope `generic-worker:cache:apple-cache`. Since CI was only running against mocks, and `GW_TESTS_USE_EXTERNAL_TASKCLUSTER` was broken (currently being fixed in https://github.com/taskcluster/taskcluster/pull/6274), it was not noticed that the scope needed to be added to role `project:taskcluster:generic-worker-tester`.