### PR TITLE
Install v4l2loopback for gcp

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
@@ -45,13 +45,12 @@ retry apt-get update
 retry apt-get install -y docker-ce docker-ce-cli containerd.io
 retry docker run hello-world
 
-# set up video device
 if [[ "%MY_CLOUD%" == "google" ]]; then
-    # Required only in GCP.
-    apt-get install linux-modules-extra-gcp -y
+    # installs the v4l2loopback kernel module
+    # used for the video device
+    # only required on gcp
+    retry apt-get install linux-modules-extra-gcp -y
 fi
-echo "v4l2loopback" | tee --append /etc/modules
-modprobe v4l2loopback video_nr=0
 
 # build generic-worker/livelog/start-worker/taskcluster-proxy from ${TASKCLUSTER_REF} commit / branch / tag etc
 retry curl -fsSL 'https://dl.google.com/go/go1.19.9.linux-amd64.tar.gz' > go.tar.gz

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -45,6 +45,13 @@ retry apt-get update
 retry apt-get install -y docker-ce docker-ce-cli containerd.io
 retry docker run hello-world
 
+if [[ "%MY_CLOUD%" == "google" ]]; then
+    # installs the v4l2loopback kernel module
+    # used for the video device
+    # only required on gcp
+    retry apt-get install linux-modules-extra-gcp -y
+fi
+
 cd /usr/local/bin
 retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
 retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/start-worker-linux-amd64" > start-worker


### PR DESCRIPTION
AWS has this kernel module by default. We will then, in generic worker, run:

```bash
modprobe v4l2loopback video_nr=0
chmod 660 /dev/video0
chown root:<taskUser> /dev/video0
```

so that the `/dev/video0` device is available to the task user.