### PR TITLE
Apply staging ubuntu 22.04 improvements to production (where effective)

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -53,16 +53,16 @@ if [[ "%MY_CLOUD%" == "google" ]]; then
 fi
 
 cd /usr/local/bin
-retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
-retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/start-worker-linux-amd64" > start-worker
-retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/livelog-linux-amd64" > livelog
-retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/taskcluster-proxy-linux-amd64" > taskcluster-proxy
+retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/generic-worker-multiuser-linux-amd64" > generic-worker
+retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/start-worker-linux-amd64" > start-worker
+retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/livelog-linux-amd64" > livelog
+retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/taskcluster-proxy-linux-amd64" > taskcluster-proxy
 chmod a+x generic-worker start-worker taskcluster-proxy livelog
 
 mkdir -p /etc/generic-worker
 mkdir -p /var/local/generic-worker
-./generic-worker --version
-./generic-worker new-ed25519-keypair --file /etc/generic-worker/ed25519_key
+/usr/local/bin/generic-worker --version
+/usr/local/bin/generic-worker new-ed25519-keypair --file /etc/generic-worker/ed25519_key
 
 # ensure host 'taskcluster' resolves to localhost
 echo 127.0.1.1 taskcluster >> /etc/hosts


### PR DESCRIPTION
We had some patches applied to staging Ubuntu 22.04 image set that were effective and would be useful for production.
Note, new image sets do not need to be built; this change simply improves reliability of the image building process when there are failures downloading release artifacts of taskcluster. But no failures occurred in the last round of image building image sets, so no new image sets are needed.