### PR TITLE
increase max capacity of gw-ubuntu-22-04 pool to 20

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -117,7 +117,7 @@ taskcluster:
       imageset: generic-worker-ubuntu-22-04
       cloud: aws
       minCapacity: 0
-      maxCapacity: 10
+      maxCapacity: 20
       workerConfig:
         genericWorker:
           config:


### PR DESCRIPTION
Now that we're shifting more CI tasks to this pool, I think it's appropriate to increase the max capacity to 20 for now.