### PR TITLE
Issue 626: grant default sentry project scope to static worker pools

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -453,6 +453,15 @@ def aws(
 
 @worker_implementation
 def generic_worker(wp, **cfg):
+    # Default value, if config value not known (static worker pools define
+    # config locally). Note, if ever a static worker pool needs to use a
+    # different value than this one, we will need to stop setting this default
+    # here, and require that projects manage their static worker pool roles
+    # directly themselves. For now, setting it here has the advantage that it
+    # is less likely for a project to forget to configure the role itself,
+    # which may otherwise go unnoticed, preventing real production panics from
+    # being reported.
+    sentryProject = "generic-worker"
     if wp.supports_worker_config():
         wp.merge_worker_config(
             WorkerPoolSettings.EXISTING_CONFIG,
@@ -493,7 +502,7 @@ def generic_worker(wp, **cfg):
             "sentryProject", "generic-worker"
         )
 
-        wp.scopes.append("auth:sentry:" + sentryProject)
+    wp.scopes.append("auth:sentry:" + sentryProject)
 
     return wp
 


### PR DESCRIPTION
Fixes #626 

Static workers don't fetch their config from Worker Manager (although, they probably should). In the current design, the configuration of the worker only lives on the worker itself, and isn't centrally managed. Just because the worker isn't provisioned by Worker Manager, it would still be possible for Worker Manager to manage its config, but that is another story.

Anyway, since Worker Manager doesn't know e.g. what the value of the Generic Worker config setting `sentryProject` is on a particular Generic Worker worker, it can't know what Sentry scope to grant role `worker-pool:<worker pool>`. Currently it therefore doesn't grant any Sentry scope to static worker pools.

We consistently use Sentry project `generic-worker` for Generic Worker workers, and Sentry project `docker-worker` for Docker Worker workers. In the Generic Worker CI, we also use Sentry project `generic-worker-tests` for Generic Worker code under test, so that we have a separate project for any panics that the CI triggers, to regular panics.

Since in theory you could set `sentryProject` to whatever you wanted, there is an argument that we should require the project to define the static worker pool scopes explicitly, but then there is a reasonable chance that someone will forget to add the sentry scopes, and nobody will notice, so I think I prefer just assuming the convention that Generic Worker uses the `generic-worker` Sentry project, and Docker Worker uses the `docker-worker` Sentry project. In the end, there is currently only one static pool in community cluster (taskcluster macOS pool) and one under development (taskcluster FreeBSD pool). So I think it isn't such a big deal right now.

Also note, if Worker Manager starts managing config of static worker pools too:
  * the correct scope name could be determined
  * static worker pool config changes could be managed by centrally by tc-admin / ci-admin, and wouldn't need operators (e.g. taskcluster team, relops team) to apply them

So I think the better long term fix will be to allow static worker pools to define worker config in taskcluster, just like the non-static pools do.