### PR TITLE
minor doc fix

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -71,7 +71,7 @@ taskcluster:
     # they all have `runTasksAsCurrentUser: true` in
     # their config so that they can run generic-worker
     # as root user in tests. this should not be used
-    # by any other tasks!
+    # by any other CI tasks!
     gw-ci-macos-13:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true


### PR DESCRIPTION
Pretty trivial fix - just wanted to highlight that this worker pool isn't for _all_ CI tasks, only for the Generic Worker CI tasks. It could have looked like it was for all CI tasks, but not other proj-taskcluster tasks, which isn't the case.