### PR TITLE
proj-tascluster generic-worker staging pool also for google/gcp

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -131,11 +131,25 @@ taskcluster:
           config:
             enableInteractive: true
 
-    gw-ubuntu-22-04-staging:
+    gw-ubuntu-staging-aws:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-22-04-staging
       cloud: aws
+      minCapacity: 0
+      maxCapacity: 1
+      workerConfig:
+        genericWorker:
+          config:
+            # While iterating on the image building process for this worker
+            # pool, useful for workers not to die immediately...
+            idleTimeoutSecs: 3600
+
+    gw-ubuntu-staging-google:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-ubuntu-22-04-staging
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 1
       workerConfig:


### PR DESCRIPTION
Note, this renames the existing staging pool in AWS, but I think that is ok, because I don't think anything references it.

Now we'll have two pools, and then worker pool name will show whether it is running in aws or google/gcp.