### PR TITLE
chore: add audio scope and switch over to gcp

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -12,7 +12,7 @@ misc:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
       # basically everyone has access to this worker (see grants below)
@@ -20,7 +20,7 @@ misc:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 2
   hooks:

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -16,7 +16,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
 
@@ -25,7 +25,7 @@ taskcluster:
       description: "Trusted worker to build Taskcluster releases (only!)"
       emailOnError: true
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 1
       workerConfig:
@@ -60,7 +60,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 20
       workerConfig:
@@ -89,9 +89,9 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
-      maxCapacity: 20
+      maxCapacity: 50
       workerConfig:
         genericWorker:
           config:
@@ -332,7 +332,7 @@ taskcluster:
     generic-worker/taskcluster-ci:
       scopes:
         - assume:project:taskcluster:generic-worker-tester
-        - generic-worker:loopback-video
+        - generic-worker:loopback-*
     # This client is used to test the client libraries in Taskcluster CI
     # Its access token is in `community-tc-secret-values.yml`.
     testing/client-libraries:


### PR DESCRIPTION
The `generic-worker:loopback-audio` scope is needed for https://github.com/taskcluster/taskcluster/pull/6419.