### PR TITLE
Fix hooks scopes and don't run tasks as root in worker pool proj-relman/ci

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -36,10 +36,6 @@ relman:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
-      workerConfig:
-        genericWorker:
-          config:
-            runTasksAsCurrentUser: true
     win2022:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -153,11 +149,13 @@ relman:
     - grant:
         - notify:email:*
         - secrets:get:project/relman/code-review/integration-testing
+        - docker-worker:cache:code-review-integration-testing
         - generic-worker:cache:code-review-integration-testing
       to: hook-id:project-relman/code-review-integration-testing
     - grant:
         - notify:email:*
         - secrets:get:project/relman/code-review/integration-production
+        - docker-worker:cache:code-review-integration-production
         - generic-worker:cache:code-review-integration-production
       to: hook-id:project-relman/code-review-integration-production
 


### PR DESCRIPTION
Hi @marco-c
It shouldn't be necessary to run tasks as root, since podman does not require permissions to use --privileged flag.
This also adds back docker-worker cache scopes to hooks, since hooks seem to be generated dynamically (I can't find them in this repo) so whatever creates the hooks probably include docker-worker scopes, so the hook-id roles need to have them.
For the repo roles, I didn't add docker-worker scopes back, because I preferred to just change them in the .taskcluster.yml file of the repo directly, and with a little bit of effort, we can switch the task definitions to native generic worker tasks, so you don't rely on the d2g translation layer. That is nice, because we'd like to get rid of it at some point, and it means you can continue to add generic-worker features to your tasks that docker-worker didn't originally support.