### PR TITLE
Add kvm.enable_vmware_backdoor modprobe option for Ubuntu x86-64.

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -58,6 +58,12 @@ retry apt-get update
 retry apt-get install -y docker-ce docker-ce-cli containerd.io
 retry docker run hello-world
 
+# configure kvm vmware backdoor
+# this enables a vmware compatible interface for kvm, and is needed for some fuzzing tasks
+cat > /etc/modprobe.d/kvm-backdoor.conf << "EOF"
+options kvm enable_vmware_backdoor=y
+EOF
+
 cd /usr/local/bin
 retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/generic-worker-multiuser-linux-${ARCH}" > generic-worker
 retry curl -fsSL "https://github.com/taskcluster/taskcluster/releases/download/${TASKCLUSTER_VERSION}/start-worker-linux-${ARCH}" > start-worker


### PR DESCRIPTION
This is not as scary as it sounds. This enables a VMware compatible interface in kvm, which is [needed for some fuzzing tasks](https://github.com/AFLplusplus/AFLplusplus/blob/stable/nyx_mode/README.md#fuzzing-with-nyx-mode).

Some very low-level explanation of the feature here: https://www.spinics.net/lists/kvm/msg160883.html