### PR TITLE
Create proj-taskcluster/old-docker-worker for testing consistency of DW and GW

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -150,6 +150,19 @@ taskcluster:
       minCapacity: 0
       maxCapacity: 10
 
+    old-docker-worker:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: docker-worker
+      cloud: gcp
+      securityGroups:
+        - ssh
+      minCapacity: 0
+      maxCapacity: 2
+      workerConfig:
+        dockerConfig:
+          allowPrivileged: true
+
   grants:
     - grant:
         - notify:manage-denylist


### PR DESCRIPTION
@abpostelnicu alerted me on slack to https://community-tc.services.mozilla.com/tasks/TPC7cceeTmCVttTtXpjIgQ/runs/0/logs/public/logs/live.log which came from https://github.com/mozilla/code-review/pull/1845#issuecomment-1677217443

Under Generic Worker there is an error `nsenter: USER is unset: No error information` which Andi has not seen before. I suspect this may be a subtle difference in behaviour between Docker Worker and Generic Worker 54.4.1 running Docker Worker payloads. Specifically, it looks like environment variable `USER` is probably not set inside the container, and it probably was under Docker Worker.

In order to test this hypothesis, and also have a platform for performing similar tests in future, I'd like to create a dedicated pool running Docker Worker under the taskcluster project, in order to be able to compare the results of a given task under the old Docker Worker release vs the new Generic Worker release.

This PR creates the Docker Worker worker pool
* proj-taskcluster/old-docker-worker

Results can be compared to running tasks under the Generic Worker worker pool
* proj-taskcluster/gw-ubuntu-22-04