### PR TITLE
Update image sets to use Generic Worker 54.4.2

### DIFF
--- a/imagesets/generic-worker-freebsd/bootstrap.sh
+++ b/imagesets/generic-worker-freebsd/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/csh
 
 # Version numbers ####################
-setenv TASKCLUSTER_VERSION v54.4.1
+setenv TASKCLUSTER_VERSION v54.4.2
 ######################################
 
 pkg update

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v54.4.1'
+TASKCLUSTER_VERSION='v54.4.2'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v54.4.1"
+$TASKCLUSTER_VERSION = "v54.4.2"
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
Just a taskcluster version bump.