### PR TITLE
Add generic-worker capability scopes for fuzzing-tc-config

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -702,6 +702,9 @@ fuzzing:
         - docker-worker:capability:device:hostSharedMemory
         - docker-worker:capability:device:loopbackAudio
         - docker-worker:capability:privileged
+        - generic-worker:capability:device:hostSharedMemory
+        - generic-worker:capability:device:loopbackAudio
+        - generic-worker:capability:privileged
         - generic-worker:os-group:proj-fuzzing/*
         - generic-worker:run-as-administrator:proj-fuzzing/*
         - hooks:modify-hook:project-fuzzing/*


### PR DESCRIPTION
This is needed so I can begin testing g-w tasks in proj-fuzzing (I don't have scopes to launch tasks until this is added to a MozillaSecurity repo).