### PR TITLE
Switch to spot instances in GCP.

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -330,7 +330,11 @@ def gcp_launch_config(zone, region, machineType, image, diskSizeGb, **cfg):
         "machineType": machineType.format(zone=zone),
         "region": region,
         "zone": zone,
-        "scheduling": {"onHostMaintenance": "terminate"},
+        "scheduling": {
+            "onHostMaintenance": "terminate",
+            "provisioningModel": "SPOT",
+            "instanceTerminationAction": "DELETE",
+        },
         "disks": [
             {
                 "type": "PERSISTENT",


### PR DESCRIPTION
Spot instances in GCP are documented here: https://cloud.google.com/compute/docs/instances/create-use-spot#api

We've been using these in fuzzing pools for some time without issue, although I have no access to the GCP console to confirm we're really getting spot instances.