### PR TITLE
Add a Fuzzing CI pool for generic-worker migration.

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -52,6 +52,13 @@ fuzzing:
       workerConfig:
         dockerConfig:
           allowPrivileged: true
+    ci-gw:
+      owner: fuzzing+taskcluster@mozilla.com
+      emailOnError: false
+      imageset: generic-worker-ubuntu-22-04
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 20
     ci-windows:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false


### PR DESCRIPTION
The intention is to migrate docker-worker tasks from `proj-fuzzing/ci`  to use d2g in this pool.