### PR TITLE
Move proj-mozci/generic-worker-ubuntu-22-04 from aws to gcp

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -100,12 +100,6 @@ generic-worker-ubuntu-22-04:
           machine-setup:
             maintainer: taskcluster-notifications+workers@mozilla.com
             script: https://github.com/mozilla/community-tc-config/blob/6052d21e19b4b9683686f38b3b1b4293757dbe1c/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
-  aws:
-    amis:
-      us-west-1: ami-09ccf92b534badc53
-      us-west-2: ami-07ce447cf5759f7a9
-      us-east-1: ami-084fc0db1984128fa
-      us-east-2: ami-01b9c0edd574d2d6b
   gcp:
     image: projects/community-tc-workers/global/images/generic-worker-ubuntu-22-04-3qgbht70b5de5vo3d73p
 generic-worker-ubuntu-22-04-arm64:

--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -34,9 +34,10 @@ mozci:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-22-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 5
+      machineType: "zones/{zone}/machineTypes/c3-standard-8"
       workerConfig:
         genericWorker:
           config:


### PR DESCRIPTION
This was the last remaining worker pool using this Generic Worker image set.

This PR moves the worker pool to GCP and removes the AWS config of the image set.

CC @marco-c

Note, the worker pool was using m5.2xlarge in AWS, which is marketed as general purpose, 8 vCPUs, 32 GB RAM:
  * https://aws.amazon.com/ec2/instance-types/m5/

In GCP this looks roughly equivalent to c3-standard-8:
  * https://cloud.google.com/compute/docs/general-purpose-machines#c3_series

I didn't research spot price differences.