### PR TITLE
chore: remove unneeded (likely?) worker config

### DIFF
--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -12,10 +12,6 @@ bugbug:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
-      workerConfig:
-        genericWorker:
-          config:
-            runTasksAsCurrentUser: true
     batch:
       owner: mcastelluccio@mozilla.com
       emailOnError: false


### PR DESCRIPTION
@marco-c I think this is safe to remove for now. Does this look fine to you? The tasks will still have root access from _within_ the container with podman. Please let us know if you run into any issues without this config.