### PR TITLE
Issue 681 - completely uninstall Windows Defender on Windows Server 2022

### DIFF
--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -24,8 +24,10 @@ function Expand-ZIPFile($file, $destination, $url)
 # allow powershell scripts to run
 Set-ExecutionPolicy Unrestricted -Force -Scope Process
 
-# Disable AV for IO speed
-Set-Service "WinDefend" -StartupType Disabled -Status Stopped
+# Issue 681: Uninstall Windows Defender as it can interfere with tasks,
+# degrade their performance, and e.g. prevents Generic Worker unit test
+# TestAbortAfterMaxRunTime from running as intended.
+Uninstall-WindowsFeature -Name Windows-Defender
 
 # Disable disk indexing
 Set-Service "WSearch" -StartupType Disabled -Status Stopped


### PR DESCRIPTION
This is the command that RelOps suggested using.

Fixes #681