### PR TITLE
Add missing file imagesets/docker-worker/gcp_base_instance_type

### DIFF
--- a/imagesets/docker-worker/gcp_base_instance_type
+++ b/imagesets/docker-worker/gcp_base_instance_type
@@ -1,0 +1,1 @@
+n2-standard-4


### PR DESCRIPTION
Looks like I forgot to commit this file when building docker-worker image on gcp. Whoops.