### PR TITLE
Code removed that is not needed on Windows Server 2022

### DIFF
--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -195,16 +195,6 @@ Expand-ZIPFile -File "C:\ProcessExplorer.zip" -Destination "C:\ProcessExplorer" 
 md "C:\ProcessMonitor"
 Expand-ZIPFile -File "C:\ProcessMonitor.zip" -Destination "C:\ProcessMonitor" -Url "https://download.sysinternals.com/files/ProcessMonitor.zip"
 
-# See https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html#ec2launch-inittasks
-# schedule one time run of EC2Launch service on first boot of instances to ensure network routes are correctly configured
-if ("%MY_CLOUD%" -eq "aws") {
-  C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
-  # make sure admin password isn't changed, since we've already captured the current random password
-  $launchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' -raw | ConvertFrom-Json
-  $launchConfig.adminPasswordType = "DoNothing"
-  $launchConfig | ConvertTo-Json -depth 32 | Set-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json'
-}
-
 # install Windows 10 SDK
 choco install -y windows-sdk-10.0
 


### PR DESCRIPTION
Around two years ago, in #444, additional code was added to work around a networking issue discovered on Windows Server 2016 in AWS. The PR conversation provides additional context.

It appears this issue no longer exists on Windows Server 2022, so the code can now be removed.

I discovered this when viewing the `bootstrap.ps1` standard error output in https://community.taskcluster-artifacts.net/HCP-7izRQ-GYybUCxYqhOA/0/public/logs/EC2Launch2911653372/err.tmp

```
C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 : The term 
'C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1' is not recognized as the 
name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or 
if a path was included, verify that the path is correct and try again.
At 
C:\Windows\system32\config\systemprofile\AppData\Local\Temp\EC2Launch2911653372\UserScript.ps1:201 
char:3
+   C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\ProgramData\...izeInstance.ps1:String) [], Comma 
   ndNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
 
Get-Content : Cannot find path 'C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json' 
because it does not exist.
At 
C:\Windows\system32\config\systemprofile\AppData\Local\Temp\EC2Launch2911653372\UserScript.ps1:203 
char:19
+ ... nchConfig = Get-Content 'C:\ProgramData\Amazon\EC2-Windows\Launch\Con ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\ProgramData\...unchConfig.json:String) [Get-Cont 
   ent], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
 
The property 'adminPasswordType' cannot be found on this object. Verify that the property exists 
and can be set.
At 
C:\Windows\system32\config\systemprofile\AppData\Local\Temp\EC2Launch2911653372\UserScript.ps1:204 
char:3
+   $launchConfig.adminPasswordType = "DoNothing"
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : PropertyNotFound
```