### PR TITLE
chore: don't specify AZ on AWS instances

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -436,7 +436,6 @@ def aws(
                     "region": region,
                     "launchConfig": {
                         "ImageId": imageIds[region],
-                        "Placement": {"AvailabilityZone": az},
                         "SubnetId": subnetId,
                         "SecurityGroupIds": groupIds,
                         "InstanceType": instanceType,


### PR DESCRIPTION
In hopes of decreasing errors like the ones below:

>Error calling AWS API: We currently do not have sufficient m5.2xlarge capacity in the Availability Zone you requested (us-east-2b). Our system will be working on provisioning additional capacity. You can currently get m5.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-2a, us-east-2c.