### PR TITLE
Add secrets for code-review integration hooks.

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -73,6 +73,8 @@ relman:
     code-review/deploy-dev: true
     code-review/deploy-production: true
     code-review/deploy-testing: true
+    code-review/integration-testing: true
+    code-review/integration-production: true
     code-review/release: true
     dump_syms/deploy: true
     microannotate/deploy: true


### PR DESCRIPTION
The [existing integration test](https://community-tc.services.mozilla.com/hooks/project-relman/code-review-integration-production) (through a taskcluster hook) has been broken for a while as it lacks a Secret.