### PR TITLE
Adds support for armDeployment in azure launch configs

### DIFF
--- a/config/azure.yml
+++ b/config/azure.yml
@@ -1,15 +1,21 @@
 ---
-# This file describes Azure constants used to build worker pools
-# It supports one top level dictionary:
+# This file describes Azure constants used for building worker pools.
+# It contains a top-level dictionary with the following keys:
 #
-# # List all the available subnets in supported locations
 # subnets:
-#   <azure-location-name>: <azure-subnet-id>
+#   A dictionary mapping Azure location names to their subnet IDs.
+#   Example:
+#     <azure-location-name>: <azure-subnet-id>
 #
-# Please do not move or edit the structure of that file as
-# it's being actively used by the fuzzing team decision task
-# to manage worker pools
-# If you remove a region, please reach out to fuzzing+taskcluster@mozilla.com
+# armDeployment:
+#   Configuration for ARM deployments, containing the following keys:
+#   - templateSpecId: The resource ID of the template spec version.
+#
+# IMPORTANT:
+# Please do not change the structure of this file. It is actively
+# used by the fuzzing team's decision task to manage worker pools.
+# If you need to remove a region, please contact fuzzing+taskcluster@mozilla.com.
+
 
 subnets:
   centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-vnets/providers/Microsoft.Network/virtualNetworks/tc-vnet-centralus/subnets/default
@@ -19,3 +25,5 @@ subnets:
   southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-vnets/providers/Microsoft.Network/virtualNetworks/tc-vnet-southcentralus/subnets/default
   westus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-vnets/providers/Microsoft.Network/virtualNetworks/tc-vnet-westus/subnets/default
   westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-vnets/providers/Microsoft.Network/virtualNetworks/tc-vnet-westus2/subnets/default
+armDeployment:
+  templateSpecId: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/templates-rg/providers/Microsoft.Resources/templateSpecs/arm-tpl-test-1/versions/3.0

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -97,26 +97,6 @@ taskcluster:
             headlessTasks: false
             idleTimeoutSecs: 300
 
-    gw-windows-2022-armtpl:
-      owner: taskcluster-notifications+workers@mozilla.com
-      emailOnError: true
-      imageset: generic-worker-win2022
-      cloud: azure
-      minCapacity: 0
-      maxCapacity: 1
-      armDeployment:
-        templateSpecId: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/templates-rg/providers/Microsoft.Resources/templateSpecs/arm-tpl-test-1/versions/2.0
-        parameters:
-          priority: Spot
-      workerManager:
-        keepDeployment: true
-        publicIp: true
-      workerConfig:
-        genericWorker:
-          config:
-            headlessTasks: true
-            idleTimeoutSecs: 300
-
     gw-ubuntu-24-04-metal:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/taskcluster/community-tc-config",
     packages=find_packages("."),
     install_requires=[
-        "tc-admin>=5.0.4",
+        "tc-admin>=5.0.5",
         "json-e>=4.7.1",
         "ruamel.yaml",
     ],


### PR DESCRIPTION
Although launch config accept much more, here we only expect `templateSpecId` to be present and some `parameters` Linked template is expected to support existing parameters and be compatible with the way we deployed so far.

Once this is tested and confirmed to be working, we might switch all azure pools to use same template and make it a default behavior