### PR TITLE
Fix broken CI git clone urls

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,18 +8,15 @@ tasks:
     repo:
       $if: 'tasks_for == "github-push"'
       then:
-        clone_url: ${event.repository.url}
-        url: ${event.repository.url}
+        url: ${event.repository.html_url}
         ref: ${event.after}
       else:
         $if: 'tasks_for == "github-pull-request"'
         then:
-          clone_url: ${event.pull_request.head.repo.clone_url}
-          url: ${event.pull_request.head.repo.url}
+          url: ${event.pull_request.head.repo.html_url}
           ref: ${event.pull_request.head.sha}
         else:
-          clone_url: ${event.repository.url}
-          url: ${event.repository.url}
+          url: ${event.repository.html_url}
           ref: ${event.release.tag_name}
   in:
     $let:
@@ -31,7 +28,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.clone_url} repo &&
+              git clone ${repo.url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
@@ -45,7 +42,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.clone_url} repo &&
+              git clone ${repo.url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
@@ -59,7 +56,7 @@ tasks:
             - '--login'
             - '-c'
             - >-
-              git clone ${repo.clone_url} repo &&
+              git clone ${repo.url} repo &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&


### PR DESCRIPTION
It looks like the github api switched from populating some fields with the github clone url with the github api url. This should fix the CI.