### PR TITLE
Bump tc-admin to >=5.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/taskcluster/community-tc-config",
     packages=find_packages("."),
     install_requires=[
-        "tc-admin>=5.1.1",
+        "tc-admin>=5.2.1",
         "json-e>=4.7.1",
         "ruamel.yaml",
     ],


### PR DESCRIPTION
Bumps the minimum required `tc-admin` version from `5.1.1` to `5.2.1`.

## Test plan

- [ ] Decision Task / `tc-admin diff` runs successfully on this PR