### PR TITLE
Tighten index insertion grants for PRs

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -56,8 +56,11 @@ mozci:
     # Routes for mozci docker images
     - grant:
         - queue:route:index.project.mozci.docker-pr.*
-        - queue:route:index.project.mozci.docker.*
       to: repo:github.com/mozilla/mozci:*
+
+    - grant:
+        - queue:route:index.project.mozci.docker.*
+      to: repo:github.com/mozilla/mozci:branch:*
 
     - grant:
         # Allow decision task to create children tasks

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -498,10 +498,15 @@ taskcluster:
         - queue:scheduler-id:taskcluster-level-1
         - queue:route:checks
         - queue:route:index.taskcluster.cache.pr.docker-images.v2.*
-        - queue:route:index.taskcluster.cache.level-1.docker-images.v2.*
       to:
         - repo:github.com/taskcluster/taskcluster:*
         - repo:github.com/taskcluster/staging-releases:*
+
+    - grant:
+        - queue:route:index.taskcluster.cache.level-1.docker-images.v2.*
+      to:
+        - repo:github.com/taskcluster/taskcluster:branch:*
+        - repo:github.com/taskcluster/staging-releases:branch:*
 
     - grant:
         - queue:create-task:medium:proj-taskcluster/gw-ubuntu-24-04-gui


### PR DESCRIPTION
Both taskcluster and mozci allowed PRs to insert indexed task in the same namespace as main, allowing PRs to pollute said index.